### PR TITLE
chore: bootstrap SDD specs and workflow commands

### DIFF
--- a/.claude/commands/sdd-ideate.md
+++ b/.claude/commands/sdd-ideate.md
@@ -1,0 +1,52 @@
+Brainstorm and create new phases for the project roadmap. Accepts an optional starting idea or theme via $ARGUMENTS.
+
+## Step 1: Gather context
+
+1. Read `specs/mission.md` to understand goals, non-goals, and design principles.
+2. Read `specs/tech-stack.md` to understand the project's technical foundation.
+3. List existing epic issues (open and closed): `gh issue list --label epic --state all --json number,title,body,state --limit 50`
+4. Scan existing phase spec directories under `specs/` to see what's been planned and implemented: `ls -d specs/*-phase-* 2>/dev/null`
+5. Summarize the current state briefly: what exists, what phases are done, what's in progress, where the roadmap currently ends.
+
+## Step 2: Brainstorm
+
+1. If $ARGUMENTS was provided, use it as a starting point for brainstorming.
+2. Consider:
+   - Gaps in the current roadmap
+   - Unaddressed mission goals
+   - Technical debt or quality improvements
+   - User-facing features or API improvements
+   - Problems or pain points not yet covered
+3. Use AskUserQuestion to brainstorm with the user:
+   - What problems or gaps are they thinking about?
+   - Are there user requests or external drivers?
+   - Any technical debt to address?
+   - What would make the library more useful?
+
+## Step 3: Propose phases
+
+1. Draft candidate phases, each with:
+   - A short name
+   - One-line description
+   - 3-6 deliverable bullets
+   - Why it matters (connection to mission goals)
+2. Present the candidates to the user via AskUserQuestion.
+3. Iterate: split large phases, merge small ones, reorder by priority, check for dependencies, verify none conflict with non-goals.
+
+## Step 4: Create phase issues
+
+Once the user approves the phases:
+
+1. For each new phase, create a GitHub issue:
+   ```
+   gh issue create --title "[epic] <name>" --label "epic,ready" --body "<phase body with deliverables and dependencies>"
+   ```
+2. Use the same body format as existing epic issues:
+   - `## Phase N: <name>` heading
+   - Deliverable bullets
+   - Dependencies section if applicable
+3. Number phases continuing from the last existing phase number.
+
+## Step 5: Summary
+
+Summarize what was added and suggest running `/sdd-plan-next-phase` to start the next one.

--- a/.claude/commands/sdd-implement.md
+++ b/.claude/commands/sdd-implement.md
@@ -1,0 +1,34 @@
+Implement the current phase based on its spec. Follow the plan, validate as you go.
+
+## Step 1: Load context
+
+1. Identify the current branch: `git branch --show-current`
+2. Find the phase spec directory under `specs/` that matches the current branch/phase. Look for the most recent `specs/*-phase-*` directory.
+3. Read all three spec files:
+   - `plan.md` — task groups and order of work
+   - `requirements.md` — what must be built and constraints
+   - `validation.md` — acceptance criteria and quality gates
+4. Read `specs/mission.md` and `specs/tech-stack.md` for project-level guidance.
+
+## Step 2: Implement task groups
+
+For each task group in `plan.md`, in order:
+
+1. Announce which task group you're starting.
+2. Implement each task in the group.
+3. After completing the group, run `make check` (or the available subset if early phases haven't set up all targets yet).
+4. Fix any issues before moving to the next group.
+5. If a decision isn't covered by the spec, use AskUserQuestion to ask the user.
+
+## Step 3: Validate
+
+After all task groups are complete:
+
+1. Run the full quality gate: `make check`
+2. Walk through each acceptance criterion in `validation.md` and verify it's met.
+3. Run any manual verification steps described in `validation.md`.
+4. If any criterion is not met, fix the issue and re-validate.
+
+## Step 4: Summary
+
+Report what was implemented, what tests pass, and any decisions made during implementation. Suggest running `/sdd-review` to review the changes before shipping.

--- a/.claude/commands/sdd-plan-next-phase.md
+++ b/.claude/commands/sdd-plan-next-phase.md
@@ -1,0 +1,65 @@
+Plan the next phase of work. Find the next epic issue, create a branch, and write a detailed spec.
+
+## Step 1: Pre-flight checks
+
+1. Run `git status`. If there are uncommitted changes, use AskUserQuestion to ask whether to stash them or abort.
+2. Check out `main` and pull latest: `git checkout main && git pull origin main`.
+
+## Step 2: Find the next phase
+
+1. List open epic issues that have the `ready` label: `gh issue list --label epic,ready --state open --json number,title,body --limit 50`
+2. List all epic issues (open and closed) to check for dependency references: `gh issue list --label epic --state all --json number,title,body,state --limit 50`
+3. For each open+ready issue, check if its body contains a "Dependencies:" line referencing other issues. Parse issue numbers from patterns like `Phase N`, `#N`, or issue URLs.
+4. An issue is eligible if it has the `ready` label AND all its dependency issues are closed.
+5. Among eligible issues, pick the one with the lowest issue number.
+6. If no ready issues exist, report the situation and use AskUserQuestion to ask the user what to do.
+7. Assign the issue to the current user: `gh issue edit <number> --add-assignee @me`
+
+## Step 3: Create branch
+
+1. Determine a branch name from the issue title. Use format `feat/<short-description>` (e.g., issue "[epic] Project scaffolding" → `feat/project-scaffolding`).
+2. Create and check out the branch: `git checkout -b <branch-name>`
+
+## Step 4: Write the phase spec
+
+1. Determine the phase number from the issue number or title.
+2. Create a spec directory: `specs/YYYY-MM-DD-phase-N-short-name/` (use today's date).
+3. Use AskUserQuestion to ask the user about:
+   - What approach to take for this phase
+   - Any constraints or decisions to be aware of
+   - How to break the work into task groups
+   - Validation criteria (how do we know it's done?)
+4. Read `specs/mission.md` and `specs/tech-stack.md` for guidance on principles and tech choices.
+5. Read the issue body for deliverables.
+
+## Step 5: Write spec files
+
+Create three files in the spec directory:
+
+### plan.md
+- Phase title and objective (one paragraph)
+- Task groups: ordered groups of related work items
+- Each task group has a name, description, and list of specific tasks
+- Include estimated complexity (small/medium/large) per task group
+
+### requirements.md
+- Functional requirements (what must the code do)
+- Non-functional requirements (performance, API design, compatibility)
+- Constraints (what we must NOT do or change)
+- Dependencies on other code or systems
+
+### validation.md
+- Acceptance criteria (specific, testable statements)
+- Test scenarios to verify
+- Quality gates that must pass (e.g., `make check`)
+- How to manually verify the work
+
+## Step 6: Review
+
+After writing all spec files, review them for:
+- Internal consistency across the three files
+- Consistency with specs/mission.md and specs/tech-stack.md
+- Completeness — are all issue deliverables covered?
+- Feasibility — are tasks appropriately scoped?
+
+Fix any issues found. Summarize what was created and suggest running `/sdd-implement` to start implementation.

--- a/.claude/commands/sdd-review.md
+++ b/.claude/commands/sdd-review.md
@@ -1,0 +1,53 @@
+Review all changes on the current branch for quality, consistency, and spec compliance.
+
+## Step 1: Gather context
+
+1. Identify the current branch: `git branch --show-current`
+2. Find the base branch (usually `main`): `git merge-base HEAD main`
+3. List all changed files: `git diff main --name-only`
+4. Find the phase spec directory under `specs/` that matches the current branch/phase.
+5. If a phase spec exists, read `plan.md`, `requirements.md`, and `validation.md`.
+6. Read `specs/mission.md`, `specs/tech-stack.md`, and `specs/conventions.md`.
+7. Find the corresponding epic issue: `gh issue list --label epic --state open --json number,title,body --limit 50` and match by phase name.
+
+## Step 2: Code review
+
+For each changed file, check:
+
+1. **Correctness** — Does the code do what it's supposed to? Are there bugs, edge cases, or error handling gaps?
+2. **Go best practices** — Idiomatic Go, proper error handling, no unnecessary complexity.
+3. **API design** — Is the public API clean, minimal, and composable? Are types well-named?
+4. **Test coverage** — Are the changes adequately tested? Are edge cases covered?
+5. **Dependencies** — Are imports minimal and necessary? No operator-controller internals?
+
+## Step 3: Spec consistency
+
+1. If a phase spec exists, verify all requirements in `requirements.md` are addressed.
+2. Check that the implementation aligns with `specs/mission.md` design principles.
+3. Verify the code follows `specs/tech-stack.md` structure and conventions.
+4. Check commit messages follow `specs/conventions.md` format (if any commits exist on the branch).
+
+## Step 4: CLAUDE.md freshness
+
+1. Read `CLAUDE.md` at the project root.
+2. Check if any of the following need updating based on changes:
+   - Build commands
+   - Architecture description
+   - Key design decisions
+3. If CLAUDE.md needs updates, apply them directly.
+
+## Step 5: Quality gate
+
+1. Run `make check` to verify everything passes.
+2. Run `make fmt` and check if it produces any changes.
+
+## Step 6: Report
+
+For issues with multiple valid solutions, use AskUserQuestion to let the user decide. Apply straightforward fixes (formatting, typos, missing error checks) directly.
+
+Summarize:
+- Issues found and fixed
+- Issues found and flagged for user decision
+- Overall assessment (ready to ship or needs more work)
+
+If ready, suggest running `/sdd-ship` to commit and publish.

--- a/.claude/commands/sdd-ship.md
+++ b/.claude/commands/sdd-ship.md
@@ -1,0 +1,42 @@
+Verify, commit, and publish the current phase's work.
+
+## Phase 1: Verify
+
+1. Run the full quality gate: `make check`
+2. Find the phase spec directory under `specs/` that matches the current branch/phase.
+3. If a phase spec exists, walk through `validation.md` acceptance criteria and verify each is met.
+4. Check CLAUDE.md freshness — verify build commands, architecture summary, directory structure, and conventions all reflect the current state.
+5. Run `make fmt` and check for uncommitted formatting changes.
+6. If any verification fails, fix it before proceeding.
+
+## Phase 2: Commit
+
+1. Read `specs/conventions.md` for commit message and PR format.
+2. Run `git status` to see all changes.
+3. Run `git diff --stat` to summarize the scope of changes.
+4. Draft a commit message following conventional commits format.
+5. Use AskUserQuestion to show the user the proposed commit message and ask for confirmation before committing.
+6. If there are multiple logical changes, ask whether to split into separate commits or keep as one.
+7. Stage and commit the changes.
+8. If there were previous review-fix commits on this branch, ask whether to squash them into a clean commit history.
+
+## Phase 3: Publish
+
+1. Use AskUserQuestion to confirm before pushing.
+2. Push the branch: `git push -u origin <branch-name>`
+3. Find the corresponding epic issue number. Search open epic issues: `gh issue list --label epic --state open --json number,title --limit 50` and match by phase/branch name.
+4. Create a PR using `gh pr create`:
+   - Title: matches the primary commit subject (conventional commit format)
+   - Body format:
+
+```markdown
+## Summary
+- <bullet points describing what changed and why>
+
+## Test Plan
+- [ ] <verification steps>
+
+Closes #<epic-issue-number>
+```
+
+5. Report the PR URL to the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# regv1render
+
+A standalone Go library for rendering OLM registry+v1 bundles to plain Kubernetes manifests. Extracted from `operator-framework/operator-controller/internal/rukpak/render` and compatible with `operator-framework/operator-lifecycle-manager` rendering behavior.
+
+## Architecture
+
+```
+*.go           Public API at repo root — consumers import github.com/perdasilva/regv1render
+testdata/      Test fixtures (ignored by go build)
+internal/      Non-public implementation details (not importable by consumers)
+cmd/rv1/       Showcase CLI tool for rendering bundles from the command line
+specs/         SDD governing specs (mission, tech stack, conventions)
+```
+
+## Design Principles
+
+- Upstream fidelity — output must match operator-controller and operator-lifecycle-manager behavior
+- Minimal dependencies — only import what's strictly necessary
+- Composable API — expose building blocks, not a monolithic render function
+- Test-driven — upstream test cases ported alongside logic
+- Makefile-driven — all operations via Make targets
+
+## Build Commands
+
+```
+make build    Build the rv1 CLI binary
+make test     Run all unit tests
+make lint     Run golangci-lint
+make fmt      Run gofmt and goimports
+make vet      Run go vet
+make tidy     Run go mod tidy
+make check    Full quality gate (fmt + vet + lint + test)
+make clean    Remove build artifacts
+```
+
+## Phase-Based Workflow
+
+Work is organized into phases tracked as GitHub issues with the `epic` label. Use these slash commands to drive the workflow:
+
+| Command | Purpose |
+|---|---|
+| `/sdd-plan-next-phase` | Find the next epic issue, create a branch, write a detailed spec |
+| `/sdd-implement` | Implement the current phase following its spec |
+| `/sdd-review` | Review all branch changes for quality and spec compliance |
+| `/sdd-ship` | Verify, commit, and publish — creates PR with `Closes #N` |
+| `/sdd-ideate` | Brainstorm and create new phases |
+
+## Conventions
+
+- **Commits:** Conventional commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`)
+- **Branches:** `type/short-description` (e.g., `feat/registry-v1-parser`)
+- **PRs:** Title matches commit subject; body has Summary + Test Plan sections

--- a/specs/conventions.md
+++ b/specs/conventions.md
@@ -1,0 +1,88 @@
+# Conventions
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>: <short description>
+
+<optional body explaining why>
+```
+
+### Types
+
+| Type | When to use |
+|---|---|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `docs` | Documentation changes |
+| `chore` | Build, CI, tooling, dependencies |
+
+### Examples
+
+```
+feat: add registry+v1 bundle parser
+
+fix: handle missing CRD annotations in bundle metadata
+
+chore: configure golangci-lint with project rules
+
+refactor: extract manifest sorting into standalone function
+
+test: add edge cases for empty bundle rendering
+```
+
+### Rules
+
+- Subject line: imperative mood, lowercase, no period, under 72 characters
+- Body (optional): explain *why*, not *what*
+- No co-author trailers required
+
+## Pull Requests
+
+### Title
+
+Match the primary commit's subject line (conventional commit format).
+
+### Description
+
+```markdown
+## Summary
+- <1-3 bullet points describing what changed and why>
+
+## Test Plan
+- [ ] <How to verify the changes>
+```
+
+### Example
+
+```markdown
+## Summary
+- Port registry+v1 bundle rendering logic from operator-controller
+- Refactor rendering logic into public API at repo root with internal/ for private code
+
+## Test Plan
+- [ ] `make check` passes
+- [ ] Upstream test cases ported and passing
+- [ ] Public API reviewed for minimal surface area
+```
+
+## Branch Naming
+
+Format: `<type>/<short-description>`
+
+| Example | When |
+|---|---|
+| `feat/registry-v1-parser` | New feature |
+| `fix/yaml-parse-error` | Bug fix |
+| `chore/ci-setup` | Build/tooling work |
+| `refactor/split-render-steps` | Refactoring |
+| `docs/api-examples` | Documentation |
+
+Rules:
+- Lowercase, hyphens for spaces
+- Keep under 50 characters
+- Use the same type prefix as the commit

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -1,0 +1,35 @@
+# Mission
+
+A standalone Go library for rendering OLM registry+v1 bundles to plain Kubernetes manifests, extracted from the `operator-framework/operator-controller` internal rendering logic and compatible with the original `operator-framework/operator-lifecycle-manager` rendering behavior.
+
+## Goals
+
+- **Faithful port of registry+v1 rendering logic** from `operator-framework/operator-controller/internal/rukpak/render`
+- **OLMv0 rendering compatibility** — respects rendering behavior from `operator-framework/operator-lifecycle-manager`
+- **Clean, minimal public API surface** — composable building blocks, not just a monolithic render function
+- **Zero dependency on operator-controller internals** — fully standalone library
+- **Well-tested** — upstream test cases ported alongside the logic, with equivalent or better coverage
+
+## Non-Goals
+
+- **No bundle fetching/downloading** — input is already-loaded bundle content
+- **No support for other bundle formats** (e.g., plain, helm) — registry+v1 only
+- **No cluster interaction** — pure offline rendering
+- The `rv1` CLI is a showcase tool, not the primary deliverable — other CLIs/tools should provide a more comprehensive experience
+
+## Design Principles
+
+- **Upstream fidelity** — rendering output must match operator-controller and operator-lifecycle-manager behavior
+- **Minimal dependencies** — only import what's strictly necessary
+- **Composable API** — expose building blocks, not just a monolithic render function
+- **Test-driven** — upstream test cases should be ported alongside the logic
+- **Makefile-driven** — all build, test, and CI operations via Makefile targets
+- **Go best practices** — idiomatic Go, standard project layout, proper error handling
+
+## Development Practices
+
+- `go vet` and `golangci-lint` must pass on all code
+- `gofmt`/`goimports` for consistent formatting
+- Unit tests with `go test` for all packages
+- Code coverage tracking
+- GitHub Actions CI on all pushes and PRs

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -1,0 +1,76 @@
+# Tech Stack
+
+## Language & Runtime
+
+- **Language:** Go 1.24
+- **Module path:** `github.com/perdasilva/regv1render`
+
+## Project Structure
+
+```
+regv1render/
+├── render.go            # public API entry points
+├── types.go             # public types and interfaces
+├── render_test.go       # tests
+├── testdata/            # test fixtures (ignored by go build)
+├── internal/            # non-public implementation details (not importable by consumers)
+├── cmd/
+│   └── rv1/             # showcase CLI tool
+│       └── main.go
+├── specs/               # SDD governing specs and phase-specific specs
+│   ├── mission.md
+│   ├── tech-stack.md
+│   ├── conventions.md
+│   └── YYYY-MM-DD-phase-N-*/   # phase specs created by /sdd-plan-next-phase
+│       ├── plan.md
+│       ├── requirements.md
+│       └── validation.md
+├── .claude/
+│   └── commands/        # SDD workflow commands
+├── .github/
+│   └── workflows/       # GitHub Actions CI
+│       └── ci.yml
+├── .golangci.yml        # golangci-lint configuration
+├── go.mod
+├── go.sum
+├── Makefile
+├── CLAUDE.md
+└── .gitignore
+```
+
+## Dependencies
+
+### Core
+
+| Dependency | Purpose |
+|---|---|
+| `k8s.io/api` | Kubernetes API types (core, apps, rbac, etc.) |
+| `k8s.io/apimachinery` | API machinery (unstructured, scheme, serialization) |
+| `sigs.k8s.io/controller-runtime` | Controller runtime client types |
+| `sigs.k8s.io/yaml` | YAML serialization |
+
+### Dev
+
+| Tool | Purpose |
+|---|---|
+| `golangci-lint` | Linting |
+| `goimports` | Import formatting |
+
+## Build Commands
+
+| Command | Description |
+|---|---|
+| `make build` | Build the rv1 CLI binary |
+| `make test` | Run all unit tests |
+| `make lint` | Run golangci-lint |
+| `make fmt` | Run gofmt and goimports |
+| `make vet` | Run go vet |
+| `make tidy` | Run go mod tidy |
+| `make check` | Run fmt + vet + lint + test (full quality gate) |
+| `make clean` | Remove build artifacts |
+
+## CI/CD
+
+- **GitHub Actions** workflow on push and pull request to main
+- Steps: checkout, setup Go 1.24, `make check`, `make build`
+- No container build at this time


### PR DESCRIPTION
## Summary
- Add governing specs: mission, tech-stack, and conventions under `specs/`
- Add 5 SDD workflow slash commands under `.claude/commands/` (plan-next-phase, implement, review, ship, ideate)
- Add CLAUDE.md with project overview, architecture, build commands, and workflow reference
- Phases tracked as GitHub issues with `epic` label (#1–#5 created)

## Test Plan
- [ ] All spec files are internally consistent (no stale `pkg/render/` references)
- [ ] Slash commands reference correct make targets, labels, and conventions
- [ ] CLAUDE.md accurately reflects specs and commands
- [ ] GitHub issues #1–#5 have correct labels and dependency declarations