### PR TITLE
chore: replace phase verbiage with epic terminology

### DIFF
--- a/.claude/commands/sdd-ideate.md
+++ b/.claude/commands/sdd-ideate.md
@@ -1,12 +1,12 @@
-Brainstorm and create new phases for the project roadmap. Accepts an optional starting idea or theme via $ARGUMENTS.
+Brainstorm and create new epics for the project roadmap. Accepts an optional starting idea or theme via $ARGUMENTS.
 
 ## Step 1: Gather context
 
 1. Read `specs/mission.md` to understand goals, non-goals, and design principles.
 2. Read `specs/tech-stack.md` to understand the project's technical foundation.
 3. List existing epic issues (open and closed): `gh issue list --label epic --state all --json number,title,body,state --limit 50`
-4. Scan existing phase spec directories under `specs/` to see what's been planned and implemented: `ls -d specs/*-phase-* 2>/dev/null`
-5. Summarize the current state briefly: what exists, what phases are done, what's in progress, where the roadmap currently ends.
+4. Scan existing spec directories under `specs/` to see what's been planned and implemented: `ls -d specs/*-issue-* 2>/dev/null`
+5. Summarize the current state briefly: what exists, what epics are done, what's in progress, what's remaining.
 
 ## Step 2: Brainstorm
 
@@ -23,29 +23,28 @@ Brainstorm and create new phases for the project roadmap. Accepts an optional st
    - Any technical debt to address?
    - What would make the library more useful?
 
-## Step 3: Propose phases
+## Step 3: Propose epics
 
-1. Draft candidate phases, each with:
+1. Draft candidate epics, each with:
    - A short name
    - One-line description
    - 3-6 deliverable bullets
    - Why it matters (connection to mission goals)
 2. Present the candidates to the user via AskUserQuestion.
-3. Iterate: split large phases, merge small ones, reorder by priority, check for dependencies, verify none conflict with non-goals.
+3. Iterate: split large epics, merge small ones, reorder by priority, check for dependencies, verify none conflict with non-goals.
 
-## Step 4: Create phase issues
+## Step 4: Create epic issues
 
-Once the user approves the phases:
+Once the user approves the epics:
 
-1. For each new phase, create a GitHub issue:
+1. For each new epic, create a GitHub issue:
    ```
-   gh issue create --title "[epic] <name>" --label "epic,ready" --body "<phase body with deliverables and dependencies>"
+   gh issue create --title "[epic] <name>" --label "epic,ready" --body "<body with deliverables and dependencies>"
    ```
 2. Use the same body format as existing epic issues:
-   - `## Phase N: <name>` heading
+   - `## <name>` heading
    - Deliverable bullets
-   - Dependencies section if applicable
-3. Number phases continuing from the last existing phase number.
+   - `**Dependencies:** #N` section if applicable
 
 ## Step 5: Summary
 

--- a/.claude/commands/sdd-implement.md
+++ b/.claude/commands/sdd-implement.md
@@ -1,9 +1,9 @@
-Implement the current phase based on its spec. Follow the plan, validate as you go.
+Implement the current epic based on its spec. Follow the plan, validate as you go.
 
 ## Step 1: Load context
 
 1. Identify the current branch: `git branch --show-current`
-2. Find the phase spec directory under `specs/` that matches the current branch/phase. Look for the most recent `specs/*-phase-*` directory.
+2. Find the spec directory under `specs/` that matches the current branch. Look for the most recent `specs/*-issue-*` directory.
 3. Read all three spec files:
    - `plan.md` — task groups and order of work
    - `requirements.md` — what must be built and constraints
@@ -16,7 +16,7 @@ For each task group in `plan.md`, in order:
 
 1. Announce which task group you're starting.
 2. Implement each task in the group.
-3. After completing the group, run `make check` (or the available subset if early phases haven't set up all targets yet).
+3. After completing the group, run `make check` (or the available subset if early epics haven't set up all targets yet).
 4. Fix any issues before moving to the next group.
 5. If a decision isn't covered by the spec, use AskUserQuestion to ask the user.
 

--- a/.claude/commands/sdd-plan-next-phase.md
+++ b/.claude/commands/sdd-plan-next-phase.md
@@ -1,18 +1,18 @@
-Plan the next phase of work. Find the next epic issue, create a branch, and write a detailed spec.
+Plan the next epic. Find the next eligible epic issue, create a branch, and write a detailed spec.
 
 ## Step 1: Pre-flight checks
 
 1. Run `git status`. If there are uncommitted changes, use AskUserQuestion to ask whether to stash them or abort.
 2. Check out `main` and pull latest: `git checkout main && git pull origin main`.
 
-## Step 2: Find the next phase
+## Step 2: Find the next epic
 
 1. List open epic issues that have the `ready` label: `gh issue list --label epic,ready --state open --json number,title,body --limit 50`
 2. List all epic issues (open and closed) to check for dependency references: `gh issue list --label epic --state all --json number,title,body,state --limit 50`
-3. For each open+ready issue, check if its body contains a "Dependencies:" line referencing other issues. Parse issue numbers from patterns like `Phase N`, `#N`, or issue URLs.
+3. For each open+ready issue, check if its body contains a "Dependencies:" line referencing other issues. Parse issue numbers from `#N` patterns or issue URLs.
 4. An issue is eligible if it has the `ready` label AND all its dependency issues are closed.
 5. Among eligible issues, pick the one with the lowest issue number.
-6. If no ready issues exist, report the situation and use AskUserQuestion to ask the user what to do.
+6. If no eligible issues exist, report the situation and use AskUserQuestion to ask the user what to do.
 7. Assign the issue to the current user: `gh issue edit <number> --add-assignee @me`
 
 ## Step 3: Create branch
@@ -20,24 +20,23 @@ Plan the next phase of work. Find the next epic issue, create a branch, and writ
 1. Determine a branch name from the issue title. Use format `feat/<short-description>` (e.g., issue "[epic] Project scaffolding" → `feat/project-scaffolding`).
 2. Create and check out the branch: `git checkout -b <branch-name>`
 
-## Step 4: Write the phase spec
+## Step 4: Write the spec
 
-1. Determine the phase number from the issue number or title.
-2. Create a spec directory: `specs/YYYY-MM-DD-phase-N-short-name/` (use today's date).
-3. Use AskUserQuestion to ask the user about:
-   - What approach to take for this phase
+1. Create a spec directory: `specs/YYYY-MM-DD-issue-N-short-name/` (use today's date and the issue number).
+2. Use AskUserQuestion to ask the user about:
+   - What approach to take for this epic
    - Any constraints or decisions to be aware of
    - How to break the work into task groups
    - Validation criteria (how do we know it's done?)
-4. Read `specs/mission.md` and `specs/tech-stack.md` for guidance on principles and tech choices.
-5. Read the issue body for deliverables.
+3. Read `specs/mission.md` and `specs/tech-stack.md` for guidance on principles and tech choices.
+4. Read the issue body for deliverables.
 
 ## Step 5: Write spec files
 
 Create three files in the spec directory:
 
 ### plan.md
-- Phase title and objective (one paragraph)
+- Title and objective (one paragraph)
 - Task groups: ordered groups of related work items
 - Each task group has a name, description, and list of specific tasks
 - Include estimated complexity (small/medium/large) per task group

--- a/.claude/commands/sdd-plan-next-phase.md
+++ b/.claude/commands/sdd-plan-next-phase.md
@@ -17,8 +17,9 @@ Plan the next epic. Find the next eligible epic issue, create a branch, and writ
 
 ## Step 3: Create branch
 
-1. Determine a branch name from the issue title. Use format `feat/<short-description>` (e.g., issue "[epic] Project scaffolding" → `feat/project-scaffolding`).
-2. Create and check out the branch: `git checkout -b <branch-name>`
+1. Determine the branch type from the nature of the epic (see `specs/conventions.md` for valid types: feat, fix, chore, refactor, docs, test). Use AskUserQuestion to confirm the branch type if it's ambiguous.
+2. Determine a branch name from the issue title. Use format `<type>/<short-description>` (e.g., issue "[epic] Project scaffolding" → `chore/project-scaffolding`, issue "[epic] rv1 CLI tool" → `feat/rv1-cli`).
+3. Create and check out the branch: `git checkout -b <branch-name>`
 
 ## Step 4: Write the spec
 

--- a/.claude/commands/sdd-review.md
+++ b/.claude/commands/sdd-review.md
@@ -5,10 +5,10 @@ Review all changes on the current branch for quality, consistency, and spec comp
 1. Identify the current branch: `git branch --show-current`
 2. Find the base branch (usually `main`): `git merge-base HEAD main`
 3. List all changed files: `git diff main --name-only`
-4. Find the phase spec directory under `specs/` that matches the current branch/phase.
-5. If a phase spec exists, read `plan.md`, `requirements.md`, and `validation.md`.
+4. Find the spec directory under `specs/` that matches the current branch.
+5. If a spec exists, read `plan.md`, `requirements.md`, and `validation.md`.
 6. Read `specs/mission.md`, `specs/tech-stack.md`, and `specs/conventions.md`.
-7. Find the corresponding epic issue: `gh issue list --label epic --state open --json number,title,body --limit 50` and match by phase name.
+7. Find the corresponding epic issue: `gh issue list --label epic --state open --json number,title,body --limit 50` and match by branch name.
 
 ## Step 2: Code review
 
@@ -22,7 +22,7 @@ For each changed file, check:
 
 ## Step 3: Spec consistency
 
-1. If a phase spec exists, verify all requirements in `requirements.md` are addressed.
+1. If a spec exists, verify all requirements in `requirements.md` are addressed.
 2. Check that the implementation aligns with `specs/mission.md` design principles.
 3. Verify the code follows `specs/tech-stack.md` structure and conventions.
 4. Check commit messages follow `specs/conventions.md` format (if any commits exist on the branch).

--- a/.claude/commands/sdd-ship.md
+++ b/.claude/commands/sdd-ship.md
@@ -1,15 +1,15 @@
-Verify, commit, and publish the current phase's work.
+Verify, commit, and publish the current epic's work.
 
-## Phase 1: Verify
+## Step 1: Verify
 
 1. Run the full quality gate: `make check`
-2. Find the phase spec directory under `specs/` that matches the current branch/phase.
-3. If a phase spec exists, walk through `validation.md` acceptance criteria and verify each is met.
+2. Find the spec directory under `specs/` that matches the current branch.
+3. If a spec exists, walk through `validation.md` acceptance criteria and verify each is met.
 4. Check CLAUDE.md freshness — verify build commands, architecture summary, directory structure, and conventions all reflect the current state.
 5. Run `make fmt` and check for uncommitted formatting changes.
 6. If any verification fails, fix it before proceeding.
 
-## Phase 2: Commit
+## Step 2: Commit
 
 1. Read `specs/conventions.md` for commit message and PR format.
 2. Run `git status` to see all changes.
@@ -20,11 +20,11 @@ Verify, commit, and publish the current phase's work.
 7. Stage and commit the changes.
 8. If there were previous review-fix commits on this branch, ask whether to squash them into a clean commit history.
 
-## Phase 3: Publish
+## Step 3: Publish
 
 1. Use AskUserQuestion to confirm before pushing.
 2. Push the branch: `git push -u origin <branch-name>`
-3. Find the corresponding epic issue number. Search open epic issues: `gh issue list --label epic --state open --json number,title --limit 50` and match by phase/branch name.
+3. Find the corresponding epic issue number. Search open epic issues: `gh issue list --label epic --state open --json number,title --limit 50` and match by branch name.
 4. Create a PR using `gh pr create`:
    - Title: matches the primary commit subject (conventional commit format)
    - Body format:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,17 +33,17 @@ make check    Full quality gate (fmt + vet + lint + test)
 make clean    Remove build artifacts
 ```
 
-## Phase-Based Workflow
+## Epic-Based Workflow
 
-Work is organized into phases tracked as GitHub issues with the `epic` label. Use these slash commands to drive the workflow:
+Work is organized into epics tracked as GitHub issues with the `epic` label. Use these slash commands to drive the workflow:
 
 | Command | Purpose |
 |---|---|
 | `/sdd-plan-next-phase` | Find the next epic issue, create a branch, write a detailed spec |
-| `/sdd-implement` | Implement the current phase following its spec |
+| `/sdd-implement` | Implement the current epic following its spec |
 | `/sdd-review` | Review all branch changes for quality and spec compliance |
 | `/sdd-ship` | Verify, commit, and publish — creates PR with `Closes #N` |
-| `/sdd-ideate` | Brainstorm and create new phases |
+| `/sdd-ideate` | Brainstorm and create new epics |
 
 ## Conventions
 

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -17,11 +17,11 @@ regv1render/
 ├── cmd/
 │   └── rv1/             # showcase CLI tool
 │       └── main.go
-├── specs/               # SDD governing specs and phase-specific specs
+├── specs/               # SDD governing specs and per-epic specs
 │   ├── mission.md
 │   ├── tech-stack.md
 │   ├── conventions.md
-│   └── YYYY-MM-DD-phase-N-*/   # phase specs created by /sdd-plan-next-phase
+│   └── YYYY-MM-DD-issue-N-*/   # epic specs created by /sdd-plan-next-phase
 │       ├── plan.md
 │       ├── requirements.md
 │       └── validation.md


### PR DESCRIPTION
## Summary
- Replace "phase" terminology with "epic" across all SDD commands and specs
- Spec directories now use `specs/YYYY-MM-DD-issue-N-*/` naming (issue number as identifier, no sequential numbering)
- Update dependency parsing to use `#N` patterns only (removed stale `Phase N` pattern)
- Update CLAUDE.md and tech-stack.md to match

## Test Plan
- [ ] No "phase" references remain in specs or commands (except the `sdd-plan-next-phase` filename)
- [ ] All commands reference correct directory patterns (`*-issue-*` not `*-phase-*`)
- [ ] Issue body templates use `## <name>` heading (no `Phase N:` prefix)