### PR TITLE
chore: add scope drift detection to sdd-review command

### DIFF
--- a/.claude/commands/sdd-review.md
+++ b/.claude/commands/sdd-review.md
@@ -27,7 +27,24 @@ For each changed file, check:
 3. Verify the code follows `specs/tech-stack.md` structure and conventions.
 4. Check commit messages follow `specs/conventions.md` format (if any commits exist on the branch).
 
-## Step 4: CLAUDE.md freshness
+## Step 4: Scope drift
+
+Compare what was actually implemented against the spec and the epic issue to detect scope changes — work that was added, removed, or changed during implementation.
+
+1. Read the epic issue body (`gh issue view <number> --json body`) and compare its deliverables against the actual changes on the branch.
+2. Read `plan.md` task groups and check whether any tasks were added, skipped, or significantly changed during implementation.
+3. Read `requirements.md` and check whether any requirements were added or dropped.
+4. For each scope change found, classify it:
+   - **Added scope** — work done that wasn't in the original plan (e.g., removed a feature, consolidated packages, added a convenience API)
+   - **Dropped scope** — planned work that wasn't done
+   - **Changed approach** — work done differently than planned
+5. If scope changes are found:
+   - Update `plan.md` to reflect what was actually delivered, not what was originally planned
+   - Update `requirements.md` and `validation.md` if requirements or acceptance criteria changed
+   - Update the epic issue body via `gh issue edit <number> --body` to reflect the actual deliverables
+   - Use AskUserQuestion if a scope change is ambiguous or if you're unsure whether a change was intentional
+
+## Step 5: CLAUDE.md freshness
 
 1. Read `CLAUDE.md` at the project root.
 2. Check if any of the following need updating based on changes:
@@ -36,17 +53,18 @@ For each changed file, check:
    - Key design decisions
 3. If CLAUDE.md needs updates, apply them directly.
 
-## Step 5: Quality gate
+## Step 6: Quality gate
 
 1. Run `make verify` to verify everything passes.
 2. Run `make fmt` and check if it produces any changes.
 
-## Step 6: Report
+## Step 7: Report
 
 For issues with multiple valid solutions, use AskUserQuestion to let the user decide. Apply straightforward fixes (formatting, typos, missing error checks) directly.
 
 Summarize:
 - Issues found and fixed
+- Scope changes detected and updated
 - Issues found and flagged for user decision
 - Overall assessment (ready to ship or needs more work)
 


### PR DESCRIPTION
## Summary
- Add Step 4 (Scope drift) to the `/sdd-review` command
- Compares actual implementation against the spec plan and epic issue to detect work that was added, dropped, or changed during implementation
- Automatically updates `plan.md`, `requirements.md`, `validation.md`, and the epic issue body to reflect what was actually delivered
- Renumbers existing steps 4-6 to 5-7

## Test Plan
- [ ] `/sdd-review` command includes scope drift detection when a spec exists
- [ ] Step references in the report section are updated (now Step 7)