### PR TITLE
docs: add examples, CONTRIBUTING.md, and README enhancements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to regv1render
+
+## Prerequisites
+
+- Go 1.25+
+- Dev tools (golangci-lint, goimports) are managed by [bingo](https://github.com/bwplotka/bingo) and built automatically on first `make` invocation — no manual install needed
+
+## Getting Started
+
+```bash
+git clone https://github.com/perdasilva/regv1render.git
+cd regv1render
+make verify   # run the full quality gate (fmt + vet + lint + test)
+make build    # build the rv1 CLI binary
+```
+
+## Making Changes
+
+1. Create a branch following the naming convention: `<type>/<short-description>`
+   - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+   - Example: `feat/new-option`, `fix/crd-parsing`, `docs/api-examples`
+
+2. Make your changes and ensure they pass:
+   ```bash
+   make verify
+   ```
+
+3. Commit using [conventional commits](https://www.conventionalcommits.org/):
+   ```
+   feat: add support for custom label injection
+   
+   Optional body explaining why, not what.
+   ```
+
+## Pull Requests
+
+- Title should match your commit subject (conventional commit format)
+- Include a description with:
+
+```markdown
+## Summary
+- <what changed and why>
+
+## Test Plan
+- [ ] <how to verify>
+```
+
+## Build Commands
+
+| Command | Description |
+|---|---|
+| `make build` | Build the rv1 CLI binary |
+| `make test` | Run all unit tests |
+| `make lint` | Run golangci-lint |
+| `make fmt` | Run gofmt and goimports |
+| `make vet` | Run go vet |
+| `make verify` | Full quality gate (fmt + vet + lint + test) |
+| `make clean` | Remove build artifacts |
+
+## Adding Dev Tools
+
+Dev tool versions are pinned in `.bingo/`. To add a new tool:
+
+```bash
+go install github.com/bwplotka/bingo@latest
+bingo get <tool-module-path>
+```
+
+## Project Structure
+
+```
+*.go           Public API (consumers import github.com/perdasilva/regv1render)
+internal/      Private implementation (render engine, bundle types, utilities)
+cmd/rv1/       CLI tool
+test/          Regression tests with golden-file fixtures
+specs/         SDD governing specs and per-epic specs
+```

--- a/README.md
+++ b/README.md
@@ -74,6 +74,37 @@ deploymentConfig:
     kubernetes.io/os: linux
 ```
 
+## OLMv0 Compatibility
+
+The library includes opt-in support for rendering behaviors from the original [operator-lifecycle-manager](https://github.com/operator-framework/operator-lifecycle-manager) (OLMv0).
+
+### Provided API ClusterRoles
+
+Use `WithProvidedAPIsClusterRoles()` to generate aggregated admin/edit/view ClusterRoles for each owned CRD, matching OLMv0 behavior:
+
+```go
+objs, err := regv1render.Render(rv1, "my-namespace",
+    regv1render.WithProvidedAPIsClusterRoles(),
+)
+```
+
+This generates 4 ClusterRoles per owned CRD:
+- `<name>-<version>-admin` — full access (`*`)
+- `<name>-<version>-edit` — write access (`create`, `update`, `patch`, `delete`)
+- `<name>-<version>-view` — read access (`get`, `list`, `watch`)
+- `<name>-<version>-crd-view` — read access to the CRD definition itself
+
+These roles use Kubernetes [aggregated ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) so they're automatically included in the built-in admin/edit/view roles.
+
+## Upstream Relationship
+
+This library extracts and consolidates the registry+v1 bundle rendering logic from two operator-framework projects:
+
+- **[operator-controller](https://github.com/operator-framework/operator-controller)** — the OLMv1 rendering pipeline (`internal/rukpak/render`), which provides the core `BundleRenderer`, validators, and resource generators
+- **[operator-lifecycle-manager](https://github.com/operator-framework/operator-lifecycle-manager)** — the OLMv0 rendering behaviors, available as opt-in options (e.g., provided API ClusterRoles)
+
+The goal is upstream fidelity — rendering output matches the upstream implementations for the same inputs. The library includes regression tests with golden-file fixtures to verify this.
+
 ## Development
 
 Requires Go 1.25+. Dev tools are managed via [bingo](https://github.com/bwplotka/bingo) and built automatically on first use.
@@ -87,6 +118,8 @@ make vet       # run go vet
 make verify    # full quality gate (fmt + vet + lint + test)
 make clean     # remove build artifacts
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 
 ## License
 

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,23 @@
 // Package regv1render renders OLM registry+v1 bundles to plain Kubernetes manifests.
+//
+// This library is extracted from the operator-framework/operator-controller rendering
+// pipeline and is compatible with the operator-framework/operator-lifecycle-manager
+// rendering behavior.
+//
+// The simplest way to render a bundle is with the top-level Render function:
+//
+//	objs, err := regv1render.Render(rv1, "install-namespace")
+//
+// For more control, use the DefaultRenderer directly or construct a custom
+// BundleRenderer with specific validators and generators.
+//
+// Bundles can be loaded from a filesystem using FromFS:
+//
+//	source := regv1render.FromFS(os.DirFS("path/to/bundle"))
+//	rv1, err := source.GetBundle()
+//
+// OLMv0 compatibility features (such as provided API ClusterRoles) are
+// available as opt-in rendering options:
+//
+//	objs, err := regv1render.Render(rv1, "ns", regv1render.WithProvidedAPIsClusterRoles())
 package regv1render

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,152 @@
+package regv1render_test
+
+import (
+	"fmt"
+	"testing/fstest"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/perdasilva/regv1render"
+)
+
+func exampleBundle() regv1render.RegistryV1 {
+	return regv1render.RegistryV1{
+		PackageName: "my-operator",
+		CSV: v1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-operator.v1.0.0"},
+			Spec: v1alpha1.ClusterServiceVersionSpec{
+				InstallModes: []v1alpha1.InstallMode{
+					{Type: v1alpha1.InstallModeTypeAllNamespaces, Supported: true},
+					{Type: v1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+					{Type: v1alpha1.InstallModeTypeSingleNamespace, Supported: true},
+				},
+				InstallStrategy: v1alpha1.NamedInstallStrategy{
+					StrategyName: "deployment",
+					StrategySpec: v1alpha1.StrategyDetailsDeployment{
+						DeploymentSpecs: []v1alpha1.StrategyDeploymentSpec{{
+							Name: "my-operator-controller",
+						}},
+					},
+				},
+				CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+					Owned: []v1alpha1.CRDDescription{{
+						Name:    "widgets.example.com",
+						Version: "v1",
+						Kind:    "Widget",
+					}},
+				},
+			},
+		},
+		CRDs: []apiextensionsv1.CustomResourceDefinition{{
+			ObjectMeta: metav1.ObjectMeta{Name: "widgets.example.com"},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "example.com",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "widgets", Singular: "widget", Kind: "Widget",
+				},
+				Scope:    apiextensionsv1.NamespaceScoped,
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1", Served: true, Storage: true}},
+			},
+		}},
+	}
+}
+
+func ExampleRender() {
+	rv1 := exampleBundle()
+
+	objs, err := regv1render.Render(rv1, "operators")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Rendered %d objects\n", len(objs))
+	// Output:
+	// Rendered 2 objects
+}
+
+func ExampleRender_withTargetNamespaces() {
+	rv1 := exampleBundle()
+
+	objs, err := regv1render.Render(rv1, "operators",
+		regv1render.WithTargetNamespaces("watch-ns"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Rendered %d objects\n", len(objs))
+	// Output:
+	// Rendered 2 objects
+}
+
+func ExampleRender_withProvidedAPIsClusterRoles() {
+	rv1 := exampleBundle()
+
+	objs, err := regv1render.Render(rv1, "operators",
+		regv1render.WithProvidedAPIsClusterRoles(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Rendered %d objects (includes provided API ClusterRoles)\n", len(objs))
+	// Output:
+	// Rendered 6 objects (includes provided API ClusterRoles)
+}
+
+func ExampleFromFS() {
+	// Create an in-memory filesystem representing a bundle
+	// In practice, this would be os.DirFS("path/to/bundle")
+	bundleFS := fstest.MapFS{
+		"metadata/annotations.yaml": &fstest.MapFile{
+			Data: []byte(`annotations:
+  operators.operatorframework.io.bundle.package.v1: my-operator
+`),
+		},
+	}
+
+	source := regv1render.FromFS(bundleFS)
+	_, err := source.GetBundle()
+
+	// This will fail because the bundle is incomplete (no CSV),
+	// but it demonstrates the FromFS API
+	if err != nil {
+		fmt.Println("FromFS loaded bundle source (bundle parsing requires a valid CSV)")
+	}
+	// Output:
+	// FromFS loaded bundle source (bundle parsing requires a valid CSV)
+}
+
+func ExampleFromBundle() {
+	rv1 := exampleBundle()
+
+	// Wrap an already-parsed bundle as a BundleSource
+	source := regv1render.FromBundle(rv1)
+	bundle, err := source.GetBundle()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Bundle: %s\n", bundle.PackageName)
+	fmt.Printf("CSV: %s\n", bundle.CSV.Name)
+	// Output:
+	// Bundle: my-operator
+	// CSV: my-operator.v1.0.0
+}
+
+func ExampleDefaultRenderer() {
+	rv1 := exampleBundle()
+
+	// Use the DefaultRenderer directly for more control
+	objs, err := regv1render.DefaultRenderer.Render(rv1, "operators")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Rendered %d objects using DefaultRenderer\n", len(objs))
+	// Output:
+	// Rendered 2 objects using DefaultRenderer
+}

--- a/specs/2026-04-22-issue-5-documentation/plan.md
+++ b/specs/2026-04-22-issue-5-documentation/plan.md
@@ -1,0 +1,54 @@
+# Documentation & Examples
+
+Provide comprehensive documentation and usage examples for the regv1render library and rv1 CLI. Add testable examples that appear in godoc, a CONTRIBUTING.md for contributors, and enhance the README with upstream relationship context.
+
+## Task Group 1: Testable examples for godoc (medium)
+
+Create `Example*` functions in `_test.go` files at the repo root that demonstrate common use cases. These are compiled and verified by `go test` and rendered in godoc.
+
+- `ExampleRender` — basic rendering of a bundle with install namespace
+- `ExampleRender_withTargetNamespaces` — rendering with specific watch namespaces
+- `ExampleRender_withProvidedAPIsClusterRoles` — rendering with OLMv0 provided API roles enabled
+- `ExampleFromFS` — loading a bundle from an `fs.FS`
+- `ExampleFromBundle` — creating a BundleSource from an already-parsed RegistryV1 struct
+- `ExampleDefaultRenderer` — using the DefaultRenderer directly for more control
+- Each example should use realistic but minimal bundle data
+- Verify all examples pass: `go test -run Example ./`
+
+## Task Group 2: Godoc audit (small)
+
+Review and improve godoc comments across the public API.
+
+- Check all exported types, functions, and variables in `render.go`, `source.go`, `certproviders.go`, `doc.go`
+- Ensure doc comments are complete, accurate, and follow Go conventions (start with the name of the thing being documented)
+- Add package-level documentation to `doc.go` describing the library's purpose, relationship to upstream, and basic usage
+- Run `go doc github.com/perdasilva/regv1render` and verify the output is clean
+
+## Task Group 3: README enhancements (small)
+
+Enhance the README with upstream relationship context and polish.
+
+- Add a section explaining the relationship to `operator-framework/operator-controller` and `operator-framework/operator-lifecycle-manager`
+- Add a section on the OLMv0 compatibility option (`WithProvidedAPIsClusterRoles`)
+- Review existing sections for accuracy after all epics
+- Ensure the README flows logically: overview → install → library usage → CLI usage → OLMv0 compat → development → license
+
+## Task Group 4: CONTRIBUTING.md (small)
+
+Create a contributor guide covering the development workflow.
+
+- Prerequisites (Go 1.25+, bingo manages dev tools)
+- Clone and build instructions
+- Running tests (`make verify`)
+- Branch naming and commit message conventions (reference specs/conventions.md)
+- PR process (Summary + Test Plan format)
+- Brief reference to the SDD workflow for maintainers
+
+## Task Group 5: Final review (small)
+
+Verify all documentation is consistent and accurate.
+
+- Run `make verify` — all tests (including examples) pass
+- Run `go doc github.com/perdasilva/regv1render` — verify clean output with examples
+- Read through README and CONTRIBUTING end-to-end for coherence
+- Update CLAUDE.md if needed

--- a/specs/2026-04-22-issue-5-documentation/requirements.md
+++ b/specs/2026-04-22-issue-5-documentation/requirements.md
@@ -1,0 +1,26 @@
+# Requirements
+
+## Functional Requirements
+
+- Testable examples exist for the core public API: `Render`, `FromFS`, `FromBundle`, `WithTargetNamespaces`, `WithProvidedAPIsClusterRoles`
+- All examples compile and pass as part of `go test`
+- All examples appear in `go doc` output
+- `CONTRIBUTING.md` exists with development workflow, conventions, and PR process
+- README documents the upstream relationship to operator-framework
+- README documents the OLMv0 compatibility option
+
+## Non-Functional Requirements
+
+- **Godoc quality** — all public types, interfaces, and functions have doc comments that follow Go conventions
+- **Example quality** — examples are realistic, minimal, and self-documenting
+- **README readability** — logical flow, no broken links, accurate commands
+
+## Constraints
+
+- Do not add new library features — this epic is documentation only
+- Examples should use testable `Example*` functions, not standalone programs
+- Do not duplicate content between README, CONTRIBUTING, and godoc — cross-reference where appropriate
+
+## Dependencies
+
+- All prior epics (#1-#4) must be complete (library, OLMv0 compat, CLI)

--- a/specs/2026-04-22-issue-5-documentation/validation.md
+++ b/specs/2026-04-22-issue-5-documentation/validation.md
@@ -1,0 +1,34 @@
+# Validation
+
+## Acceptance Criteria
+
+1. `go test -run Example ./` passes — all testable examples compile and run
+2. `go doc github.com/perdasilva/regv1render` shows examples in output
+3. All public types and functions have godoc comments
+4. CONTRIBUTING.md exists with prerequisites, build, test, conventions, and PR process
+5. README has upstream relationship section
+6. README has OLMv0 compatibility section
+7. `make verify` passes
+8. `make build` still produces a working rv1 binary
+
+## Test Scenarios
+
+- Run `go test -run Example -v ./` — verify all examples pass and produce expected output
+- Run `go doc github.com/perdasilva/regv1render Render` — verify example appears
+- Run `go doc github.com/perdasilva/regv1render FromFS` — verify example appears
+- Read CONTRIBUTING.md — verify it covers clone, build, test, branch, commit, PR
+- Read README — verify upstream relationship section is present and accurate
+- Read README — verify OLMv0 section explains WithProvidedAPIsClusterRoles
+
+## Quality Gates
+
+- `make verify` (fmt + vet + lint + test)
+- `make build`
+- All existing tests pass unchanged
+- New examples pass as part of `go test`
+
+## Manual Verification
+
+1. Run `go doc github.com/perdasilva/regv1render` — review the full package documentation
+2. Read README.md end-to-end — verify it tells a coherent story
+3. Read CONTRIBUTING.md — verify a new contributor could follow the instructions


### PR DESCRIPTION
## Summary
- Add 6 testable `Example*` functions for godoc: `ExampleRender`, `ExampleRender_withTargetNamespaces`, `ExampleRender_withProvidedAPIsClusterRoles`, `ExampleFromFS`, `ExampleFromBundle`, `ExampleDefaultRenderer`
- Enhance `doc.go` with package overview, code snippets, and upstream context
- Add `CONTRIBUTING.md` with prerequisites, build, test, branch/commit conventions, PR process, and project structure
- Expand README with upstream relationship section (operator-controller + operator-lifecycle-manager) and OLMv0 compatibility section (WithProvidedAPIsClusterRoles details)
- Add link to CONTRIBUTING.md from README

## Test Plan
- [ ] `go test -run Example -v ./` — all 6 examples pass
- [ ] `go doc github.com/perdasilva/regv1render` — shows package overview and examples
- [ ] `make verify` passes
- [ ] README reads coherently end-to-end
- [ ] CONTRIBUTING.md instructions are followable by a new contributor

Closes #5