### PR TITLE
chore: add epic issue template optimized for agent consumption

### DIFF
--- a/.claude/commands/sdd-ideate.md
+++ b/.claude/commands/sdd-ideate.md
@@ -45,7 +45,7 @@ Once the user approves the epics:
    - `### Additional context` — optional extra info
 2. Create via:
    ```
-   gh issue create --title "[epic] <name>" --label "epic,ready" --body "<body following the sections above>"
+   gh issue create --title "[epic] <name>" --label "epic" --body "<body following the sections above>"
    ```
 
 ## Step 5: Summary

--- a/.claude/commands/sdd-ideate.md
+++ b/.claude/commands/sdd-ideate.md
@@ -37,14 +37,16 @@ Brainstorm and create new epics for the project roadmap. Accepts an optional sta
 
 Once the user approves the epics:
 
-1. For each new epic, create a GitHub issue:
+1. For each new epic, create a GitHub issue using the epic template. The rendered body must contain these sections so agents can parse them:
+   - `### Summary` — one or two sentences
+   - `### Deliverables` — bullet list of concrete work items
+   - `### Dependencies` — `#N` issue references (or "None")
+   - `### Scope` — small, medium, or large
+   - `### Additional context` — optional extra info
+2. Create via:
    ```
-   gh issue create --title "[epic] <name>" --label "epic,ready" --body "<body with deliverables and dependencies>"
+   gh issue create --title "[epic] <name>" --label "epic,ready" --body "<body following the sections above>"
    ```
-2. Use the same body format as existing epic issues:
-   - `## <name>` heading
-   - Deliverable bullets
-   - `**Dependencies:** #N` section if applicable
 
 ## Step 5: Summary
 

--- a/.claude/commands/sdd-plan-next-phase.md
+++ b/.claude/commands/sdd-plan-next-phase.md
@@ -9,7 +9,7 @@ Plan the next epic. Find the next eligible epic issue, create a branch, and writ
 
 1. List open epic issues that have the `ready` label: `gh issue list --label epic,ready --state open --json number,title,body --limit 50`
 2. List all epic issues (open and closed) to check for dependency references: `gh issue list --label epic --state all --json number,title,body,state --limit 50`
-3. For each open+ready issue, check if its body contains a "Dependencies:" line referencing other issues. Parse issue numbers from `#N` patterns or issue URLs.
+3. For each open+ready issue, check if its body contains a "Dependencies" section (either `**Dependencies:**` or `### Dependencies`) referencing other issues. Parse issue numbers from `#N` patterns or issue URLs.
 4. An issue is eligible if it has the `ready` label AND all its dependency issues are closed.
 5. Among eligible issues, pick the one with the lowest issue number.
 6. If no eligible issues exist, report the situation and use AskUserQuestion to ask the user what to do.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,6 +1,6 @@
 name: Epic
 description: Define a new epic for the project roadmap
-labels: ["epic", "ready"]
+labels: ["epic"]
 title: "[epic] "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,68 @@
+name: Epic
+description: Define a new epic for the project roadmap
+labels: ["epic", "ready"]
+title: "[epic] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Define a unit of work for the project roadmap. Each epic becomes a branch, a spec, and a PR.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what this epic delivers and why.
+      placeholder: "Add support for X so that consumers can Y."
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+      description: |
+        Bullet list of concrete deliverables. Each item should be verifiable.
+        Use imperative mood ("Add X", "Port Y", "Create Z").
+      placeholder: |
+        - Add `WithFoo()` rendering option
+        - Port upstream tests for Foo
+        - Update README with Foo usage
+      value: |
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: |
+        List epic issues that must be closed before this one can start.
+        Use `#N` issue references. Leave empty if none.
+      placeholder: "#2, #3"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Estimated size of this epic.
+      options:
+        - small (1-2 files, <100 lines)
+        - medium (3-10 files, 100-500 lines)
+        - large (10+ files, 500+ lines)
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: |
+        Any extra information an agent or contributor needs: upstream references,
+        design constraints, related issues, links to code or docs.
+      placeholder: "See upstream implementation at https://github.com/..."
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/epic.yml` with structured fields: Summary, Deliverables, Dependencies, Scope, Additional context
- Template auto-applies `epic` and `ready` labels and prefills `[epic]` title
- Fields are designed for reliable agent parsing (section headings, `#N` references, dropdown for scope)
- Update `sdd-ideate` command to reference the template format when creating issues
- Update `sdd-plan-next-phase` to parse both old (`**Dependencies:**`) and new (`### Dependencies`) formats

## Test Plan
- [ ] New issue form appears at github.com/perdasilva/regv1render/issues/new/choose with "Epic" option
- [ ] Created issues have `epic` and `ready` labels auto-applied
- [ ] `sdd-plan-next-phase` can parse dependencies from template-created issues
- [ ] `sdd-ideate` creates issues matching the template format