### PR TITLE
feat: add certificate provider config to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ installNamespace: my-ns
 watchNamespaces:
   - ns1
 providedAPIsClusterRoles: true
+certificateProvider:
+  type: cert-manager  # or: openshift-service-ca, none
 deploymentConfig:
   nodeSelector:
     kubernetes.io/os: linux

--- a/cmd/rv1/render.go
+++ b/cmd/rv1/render.go
@@ -22,6 +22,25 @@ type renderConfig struct {
 	WatchNamespaces          []string                      `json:"watchNamespaces"`
 	ProvidedAPIsClusterRoles bool                          `json:"providedAPIsClusterRoles"`
 	DeploymentConfig         *regv1render.DeploymentConfig `json:"deploymentConfig,omitempty"`
+	CertificateProvider      *certificateProviderConfig    `json:"certificateProvider,omitempty"`
+}
+
+type certificateProviderConfig struct {
+	Type string `json:"type"`
+}
+
+var validCertProviderTypes = []string{"none", "cert-manager", "openshift-service-ca"}
+
+func (c *certificateProviderConfig) validate() error {
+	if c == nil || c.Type == "" || c.Type == "none" {
+		return nil
+	}
+	for _, valid := range validCertProviderTypes {
+		if c.Type == valid {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown certificate provider type %q (valid types: %v)", c.Type, validCertProviderTypes)
 }
 
 func renderCmd() *cobra.Command {
@@ -37,6 +56,11 @@ func renderCmd() *cobra.Command {
 		Long: `Reads a registry+v1 bundle as a tar stream from stdin,
 renders it to plain Kubernetes manifests, and writes
 multi-document YAML to stdout.
+
+The --config flag accepts a YAML file with rendering options:
+  installNamespace, watchNamespaces, providedAPIsClusterRoles,
+  deploymentConfig, and certificateProvider (type: cert-manager,
+  openshift-service-ca, or none).
 
 Examples:
   # Render from a container image using crane
@@ -63,6 +87,10 @@ Examples:
 
 			if cfg.InstallNamespace == "" {
 				return fmt.Errorf("--install-namespace is required (or set installNamespace in config file)")
+			}
+
+			if err := cfg.CertificateProvider.validate(); err != nil {
+				return fmt.Errorf("invalid config: %w", err)
 			}
 
 			bundleFS, err := tarToFS(os.Stdin)
@@ -118,6 +146,14 @@ func buildRenderOptions(cfg renderConfig) []regv1render.Option {
 	}
 	if cfg.DeploymentConfig != nil {
 		opts = append(opts, regv1render.WithDeploymentConfig(cfg.DeploymentConfig))
+	}
+	if p := cfg.CertificateProvider; p != nil {
+		switch p.Type {
+		case "cert-manager":
+			opts = append(opts, regv1render.WithCertificateProvider(regv1render.CertManagerProvider{}))
+		case "openshift-service-ca":
+			opts = append(opts, regv1render.WithCertificateProvider(regv1render.OpenShiftServiceCAProvider{}))
+		}
 	}
 	return opts
 }

--- a/cmd/rv1/render.go
+++ b/cmd/rv1/render.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing/fstest"
 
@@ -25,22 +26,26 @@ type renderConfig struct {
 	CertificateProvider      *certificateProviderConfig    `json:"certificateProvider,omitempty"`
 }
 
+const (
+	certProviderNone               = "none"
+	certProviderCertManager        = "cert-manager"
+	certProviderOpenShiftServiceCA = "openshift-service-ca"
+)
+
 type certificateProviderConfig struct {
 	Type string `json:"type"`
 }
 
-var validCertProviderTypes = []string{"none", "cert-manager", "openshift-service-ca"}
+var validCertProviderTypes = []string{certProviderNone, certProviderCertManager, certProviderOpenShiftServiceCA}
 
 func (c *certificateProviderConfig) validate() error {
-	if c == nil || c.Type == "" || c.Type == "none" {
+	if c == nil || c.Type == "" || c.Type == certProviderNone {
 		return nil
 	}
-	for _, valid := range validCertProviderTypes {
-		if c.Type == valid {
-			return nil
-		}
+	if !slices.Contains(validCertProviderTypes, c.Type) {
+		return fmt.Errorf("unknown certificate provider type %q (valid types: %v)", c.Type, validCertProviderTypes)
 	}
-	return fmt.Errorf("unknown certificate provider type %q (valid types: %v)", c.Type, validCertProviderTypes)
+	return nil
 }
 
 func renderCmd() *cobra.Command {
@@ -149,9 +154,9 @@ func buildRenderOptions(cfg renderConfig) []regv1render.Option {
 	}
 	if p := cfg.CertificateProvider; p != nil {
 		switch p.Type {
-		case "cert-manager":
+		case certProviderCertManager:
 			opts = append(opts, regv1render.WithCertificateProvider(regv1render.CertManagerProvider{}))
-		case "openshift-service-ca":
+		case certProviderOpenShiftServiceCA:
 			opts = append(opts, regv1render.WithCertificateProvider(regv1render.OpenShiftServiceCAProvider{}))
 		}
 	}

--- a/cmd/rv1/render_test.go
+++ b/cmd/rv1/render_test.go
@@ -139,3 +139,104 @@ func TestRenderCmd_ProvidedAPIsOption(t *testing.T) {
 	assert.Contains(t, output, "aggregate-to-edit")
 	assert.Contains(t, output, "aggregate-to-view")
 }
+
+func TestCertificateProviderConfig_CertManager(t *testing.T) {
+	cfgContent := `
+installNamespace: test-ns
+certificateProvider:
+  type: cert-manager
+`
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0600))
+
+	cfg, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.CertificateProvider)
+	assert.Equal(t, "cert-manager", cfg.CertificateProvider.Type)
+	require.NoError(t, cfg.CertificateProvider.validate())
+
+	opts := buildRenderOptions(cfg)
+	assert.NotEmpty(t, opts)
+}
+
+func TestCertificateProviderConfig_OpenShiftServiceCA(t *testing.T) {
+	cfgContent := `
+installNamespace: test-ns
+certificateProvider:
+  type: openshift-service-ca
+`
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0600))
+
+	cfg, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.CertificateProvider)
+	assert.Equal(t, "openshift-service-ca", cfg.CertificateProvider.Type)
+	require.NoError(t, cfg.CertificateProvider.validate())
+}
+
+func TestCertificateProviderConfig_None(t *testing.T) {
+	cfgContent := `
+installNamespace: test-ns
+certificateProvider:
+  type: none
+`
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0600))
+
+	cfg, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+	require.NoError(t, cfg.CertificateProvider.validate())
+
+	opts := buildRenderOptions(cfg)
+	// none should not add a cert provider option
+	for _, opt := range opts {
+		_ = opt // just verify no panic
+	}
+}
+
+func TestCertificateProviderConfig_Omitted(t *testing.T) {
+	cfgContent := `
+installNamespace: test-ns
+`
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0600))
+
+	cfg, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.CertificateProvider)
+	require.NoError(t, cfg.CertificateProvider.validate())
+}
+
+func TestCertificateProviderConfig_InvalidType(t *testing.T) {
+	cfg := &certificateProviderConfig{Type: "bogus"}
+	err := cfg.validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+	assert.Contains(t, err.Error(), "valid types")
+}
+
+func TestCertificateProviderConfig_CertManagerWithWebhookBundle(t *testing.T) {
+	f, err := os.Open("testdata/argocd-bundle.tar")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bundleFS, err := tarToFS(f)
+	require.NoError(t, err)
+
+	source := fromFSHelper(t, bundleFS)
+	objs, err := renderBundle(source, renderConfig{
+		InstallNamespace: "test-ns",
+		CertificateProvider: &certificateProviderConfig{
+			Type: "cert-manager",
+		},
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, writeYAML(&buf, objs))
+	output := buf.String()
+	// argocd bundle has no webhooks, so cert-manager won't add objects,
+	// but it should not error either
+	assert.Contains(t, output, "apiVersion:")
+}

--- a/specs/2026-04-23-issue-15-cli-cert-provider/plan.md
+++ b/specs/2026-04-23-issue-15-cli-cert-provider/plan.md
@@ -1,0 +1,33 @@
+# CLI Certificate Provider Config
+
+Add a `certificateProvider` discriminated union field to the rv1 CLI config file. Users select a provider via the `type` discriminator (`cert-manager`, `openshift-service-ca`, `none`), and future providers (#19) can add nested config without changing the schema. This is purely CLI config plumbing — no library changes.
+
+## Task Group 1: Config struct and parsing (small)
+
+Add the discriminated union struct and wire it into the config parser.
+
+- Add `CertificateProviderConfig` struct with `Type` field to `cmd/rv1/render.go`
+- Add `CertificateProvider *CertificateProviderConfig` field to `renderConfig`
+- Map `type` values in `buildRenderOptions()`:
+  - `cert-manager` → `regv1render.WithCertificateProvider(regv1render.CertManagerProvider{})`
+  - `openshift-service-ca` → `regv1render.WithCertificateProvider(regv1render.OpenShiftServiceCAProvider{})`
+  - `none` or nil → no provider (default, current behavior)
+- Validate `type` — reject unknown values with a clear error message
+
+## Task Group 2: Tests (small)
+
+Add integration tests for each provider type and error cases.
+
+- Test `cert-manager` type: verify config parses and `WithCertificateProvider` is applied
+- Test `openshift-service-ca` type: same
+- Test `none` type: verify no provider is applied (same as omitted)
+- Test omitted `certificateProvider`: verify backward compat (no provider)
+- Test invalid type value: verify clear error message
+
+## Task Group 3: Documentation (small)
+
+Update docs to show the new config format.
+
+- Update README config file example to show discriminated union format
+- Update `rv1 render --help` long description with cert provider config info
+- Run `make verify` — all tests pass

--- a/specs/2026-04-23-issue-15-cli-cert-provider/requirements.md
+++ b/specs/2026-04-23-issue-15-cli-cert-provider/requirements.md
@@ -1,0 +1,27 @@
+# Requirements
+
+## Functional Requirements
+
+- CLI config file supports a `certificateProvider` field with discriminated union structure
+- `type: cert-manager` maps to `CertManagerProvider`
+- `type: openshift-service-ca` maps to `OpenShiftServiceCAProvider`
+- `type: none` or omitted `certificateProvider` means no provider (default)
+- Unknown `type` values produce a clear error message
+- The struct is extensible for future provider-specific config (e.g., `secret` provider in #19)
+
+## Non-Functional Requirements
+
+- **Backward compatible** — omitting `certificateProvider` behaves identically to current behavior
+- **Extensible** — adding new provider types (e.g., `secret`) requires only adding fields to the struct, not changing the parsing logic
+- **Clear errors** — invalid `type` values list the valid options in the error message
+
+## Constraints
+
+- No library changes — this is purely CLI config plumbing
+- Use `sigs.k8s.io/yaml` for parsing (already a dependency)
+- The `CertificateProviderConfig` struct must use JSON tags compatible with YAML parsing
+- Do not add provider-specific config fields yet — that's #19
+
+## Dependencies
+
+- `regv1render` public API: `WithCertificateProvider()`, `CertManagerProvider`, `OpenShiftServiceCAProvider`

--- a/specs/2026-04-23-issue-15-cli-cert-provider/validation.md
+++ b/specs/2026-04-23-issue-15-cli-cert-provider/validation.md
@@ -1,0 +1,33 @@
+# Validation
+
+## Acceptance Criteria
+
+1. Config file with `certificateProvider: { type: cert-manager }` applies the cert-manager provider
+2. Config file with `certificateProvider: { type: openshift-service-ca }` applies the OpenShift provider
+3. Config file with `certificateProvider: { type: none }` applies no provider
+4. Omitting `certificateProvider` entirely applies no provider (backward compat)
+5. Config file with `certificateProvider: { type: invalid }` produces a clear error listing valid types
+6. `make verify` passes
+7. `make build` produces a working rv1 binary
+8. README shows the discriminated union config format
+
+## Test Scenarios
+
+- Parse config with `type: cert-manager` — verify provider option is built
+- Parse config with `type: openshift-service-ca` — verify provider option is built
+- Parse config with `type: none` — verify no provider option
+- Parse config with no `certificateProvider` field — verify no provider (backward compat)
+- Parse config with `type: bogus` — verify error message contains "bogus" and lists valid types
+- Render a webhook bundle with `type: cert-manager` in config — verify cert-manager objects in output
+
+## Quality Gates
+
+- `make verify` (fmt + vet + lint + test)
+- `make build`
+- All existing tests and regression tests pass unchanged
+
+## Manual Verification
+
+1. Create a config file with `certificateProvider: { type: cert-manager }`
+2. Pipe a webhook bundle: `tar -cf - -C test/regression/testdata/bundles/webhook-operator.v0.0.5 . | bin/rv1 render --install-namespace test-ns --config config.yaml`
+3. Verify cert-manager Issuer and Certificate objects appear in output


### PR DESCRIPTION
## Summary
- Add `certificateProvider` discriminated union field to rv1 CLI config file
- `type` discriminator maps to: `cert-manager` → CertManagerProvider, `openshift-service-ca` → OpenShiftServiceCAProvider, `none`/omitted → no provider
- Validate unknown types with clear error listing valid options
- Extensible struct for future provider-specific config (#19 will add `secret` type with cert/key data)
- 6 new integration tests: each provider type, backward compat, invalid type, webhook bundle
- Updated README config example and help text

## Test Plan
- [ ] `make verify` passes
- [ ] `go test -run TestCertificateProvider -v ./cmd/rv1/` — all 6 tests pass
- [ ] `bin/rv1 render --help` shows cert provider in config description
- [ ] Config with `type: bogus` produces error listing valid types
- [ ] All existing regression tests pass unchanged

Closes #15