### PR TITLE
refactor: replace BundleValidator function-slice with interface and concrete Validator

### DIFF
--- a/internal/render/registryv1/registryv1.go
+++ b/internal/render/registryv1/registryv1.go
@@ -3,41 +3,18 @@ package registryv1
 import (
 	"github.com/perdasilva/regv1render/internal/render"
 	"github.com/perdasilva/regv1render/internal/render/registryv1/generators"
-	"github.com/perdasilva/regv1render/internal/render/registryv1/validators"
+	"github.com/perdasilva/regv1render/internal/render/registryv1/validator"
 )
 
 // Renderer renders registry+v1 bundles into plain kubernetes manifests
 var Renderer = render.BundleRenderer{
-	BundleValidator:    BundleValidator,
+	BundleValidator:    validator.BundleValidator{},
 	ResourceGenerators: ResourceGenerators,
-}
-
-// BundleValidator validates RegistryV1 bundles
-var BundleValidator = render.BundleValidator{
-	// NOTE: if you update this list, Test_BundleValidatorHasAllValidationFns will fail until
-	// you bring the same changes over to that test. This helps ensure all validation rules are executed
-	// while giving us the flexibility to test each validation function individually
-	validators.CheckDeploymentSpecUniqueness,
-	validators.CheckDeploymentNameIsDNS1123SubDomain,
-	validators.CheckCRDResourceUniqueness,
-	validators.CheckOwnedCRDExistence,
-	validators.CheckPackageNameNotEmpty,
-	validators.CheckConversionWebhookSupport,
-	validators.CheckWebhookDeploymentReferentialIntegrity,
-	validators.CheckWebhookNameUniqueness,
-	validators.CheckWebhookNameIsDNS1123SubDomain,
-	validators.CheckConversionWebhookCRDReferenceUniqueness,
-	validators.CheckConversionWebhooksReferenceOwnedCRDs,
-	validators.CheckWebhookRules,
-	validators.CheckObjectSupport,
 }
 
 // ResourceGenerators a slice of ResourceGenerators required to generate plain resource manifests for
 // registry+v1 bundles
 var ResourceGenerators = []render.ResourceGenerator{
-	// NOTE: if you update this list, Test_ResourceGeneratorsHasAllGenerators will fail until
-	// you bring the same changes over to that test. This helps ensure all validation rules are executed
-	// while giving us the flexibility to test each generator individually
 	generators.BundleCSVServiceAccountGenerator,
 	generators.BundleCSVPermissionsGenerator,
 	generators.BundleCSVClusterPermissionsGenerator,

--- a/internal/render/registryv1/registryv1_test.go
+++ b/internal/render/registryv1/registryv1_test.go
@@ -15,34 +15,9 @@ import (
 	"github.com/perdasilva/regv1render/internal/render"
 	"github.com/perdasilva/regv1render/internal/render/registryv1"
 	"github.com/perdasilva/regv1render/internal/render/registryv1/generators"
-	"github.com/perdasilva/regv1render/internal/render/registryv1/validators"
 	. "github.com/perdasilva/regv1render/internal/util/testutil"
 	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
 )
-
-func Test_BundleValidatorHasAllValidationFns(t *testing.T) {
-	expectedValidationFns := []func(v1 *bundle.RegistryV1) []error{
-		validators.CheckDeploymentSpecUniqueness,
-		validators.CheckDeploymentNameIsDNS1123SubDomain,
-		validators.CheckCRDResourceUniqueness,
-		validators.CheckOwnedCRDExistence,
-		validators.CheckPackageNameNotEmpty,
-		validators.CheckConversionWebhookSupport,
-		validators.CheckWebhookDeploymentReferentialIntegrity,
-		validators.CheckWebhookNameUniqueness,
-		validators.CheckWebhookNameIsDNS1123SubDomain,
-		validators.CheckConversionWebhookCRDReferenceUniqueness,
-		validators.CheckConversionWebhooksReferenceOwnedCRDs,
-		validators.CheckWebhookRules,
-		validators.CheckObjectSupport,
-	}
-	actualValidationFns := registryv1.BundleValidator
-
-	require.Len(t, actualValidationFns, len(expectedValidationFns))
-	for i := range expectedValidationFns {
-		require.Equal(t, reflect.ValueOf(expectedValidationFns[i]).Pointer(), reflect.ValueOf(actualValidationFns[i]).Pointer(), "bundle validator has unexpected validation function")
-	}
-}
 
 func Test_ResourceGeneratorsHasAllGenerators(t *testing.T) {
 	expectedGenerators := []render.ResourceGenerator{
@@ -85,15 +60,9 @@ func Test_Renderer_Success(t *testing.T) {
 	}
 
 	objs, err := registryv1.Renderer.Render(someBundle, "install-namespace")
-	t.Log("Check renderer returns objects and no errors")
 	require.NoError(t, err)
 	require.NotEmpty(t, objs)
-
-	t.Log("Check renderer returns a single object")
-	// bundle only contains a service - bundle csv is empty
 	require.Len(t, objs, 1)
-
-	t.Log("Check correct name and that the correct namespace was applied")
 	require.Equal(t, "my-service", objs[0].GetName())
 	require.Equal(t, "install-namespace", objs[0].GetNamespace())
 }
@@ -118,7 +87,6 @@ func Test_Renderer_Failure_UnsupportedKind(t *testing.T) {
 	}
 
 	objs, err := registryv1.Renderer.Render(someBundle, "install-namespace")
-	t.Log("Check renderer returns objects and no errors")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported resource")
 	require.Empty(t, objs)

--- a/internal/render/registryv1/validator/validator.go
+++ b/internal/render/registryv1/validator/validator.go
@@ -1,4 +1,4 @@
-package validators
+package validator
 
 import (
 	"cmp"
@@ -15,11 +15,48 @@ import (
 	regv1bundle "github.com/operator-framework/operator-registry/pkg/lib/bundle"
 
 	"github.com/perdasilva/regv1render/internal/bundle"
+	"github.com/perdasilva/regv1render/internal/render"
 )
 
-// CheckDeploymentSpecUniqueness checks that each strategy deployment spec in the csv has a unique name.
+// BundleValidator validates a RegistryV1 bundle by running all checks.
+type BundleValidator struct{}
+
+type namedCheck struct {
+	name string
+	fn   func(*bundle.RegistryV1) []error
+}
+
+// Validate runs all validation checks and returns a joined error
+// wrapping each failure in a ValidationError with the check name.
+func (v BundleValidator) Validate(rv1 *bundle.RegistryV1) error {
+	checks := []namedCheck{
+		{"DeploymentSpecUniqueness", checkDeploymentSpecUniqueness},
+		{"DeploymentNameDNS1123", checkDeploymentNameIsDNS1123SubDomain},
+		{"CRDResourceUniqueness", checkCRDResourceUniqueness},
+		{"OwnedCRDExistence", checkOwnedCRDExistence},
+		{"PackageNameNotEmpty", checkPackageNameNotEmpty},
+		{"ConversionWebhookSupport", checkConversionWebhookSupport},
+		{"WebhookDeploymentReferentialIntegrity", checkWebhookDeploymentReferentialIntegrity},
+		{"WebhookNameUniqueness", checkWebhookNameUniqueness},
+		{"WebhookNameDNS1123", checkWebhookNameIsDNS1123SubDomain},
+		{"ConversionWebhookCRDReferenceUniqueness", checkConversionWebhookCRDReferenceUniqueness},
+		{"ConversionWebhooksReferenceOwnedCRDs", checkConversionWebhooksReferenceOwnedCRDs},
+		{"WebhookRules", checkWebhookRules},
+		{"ObjectSupport", checkObjectSupport},
+	}
+
+	var errs []error
+	for _, check := range checks {
+		for _, err := range check.fn(rv1) {
+			errs = append(errs, &render.ValidationError{Check: check.name, Err: err})
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// checkDeploymentSpecUniqueness checks that each strategy deployment spec in the csv has a unique name.
 // Errors are sorted by deployment name.
-func CheckDeploymentSpecUniqueness(rv1 *bundle.RegistryV1) []error {
+func checkDeploymentSpecUniqueness(rv1 *bundle.RegistryV1) []error {
 	deploymentNameSet := sets.Set[string]{}
 	duplicateDeploymentNames := sets.Set[string]{}
 	for _, dep := range rv1.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
@@ -38,7 +75,7 @@ func CheckDeploymentSpecUniqueness(rv1 *bundle.RegistryV1) []error {
 
 // CheckDeploymentNameIsDNS1123SubDomain checks each deployment strategy spec name complies with the Kubernetes
 // resource naming conversions
-func CheckDeploymentNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
+func checkDeploymentNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
 	deploymentNameErrMap := map[string][]string{}
 	for _, dep := range rv1.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
 		errs := validation.IsDNS1123Subdomain(dep.Name)
@@ -56,7 +93,7 @@ func CheckDeploymentNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
 }
 
 // CheckOwnedCRDExistence checks bundle owned custom resource definitions declared in the csv exist in the bundle
-func CheckOwnedCRDExistence(rv1 *bundle.RegistryV1) []error {
+func checkOwnedCRDExistence(rv1 *bundle.RegistryV1) []error {
 	crdsNames := sets.Set[string]{}
 	for _, crd := range rv1.CRDs {
 		crdsNames.Insert(crd.Name)
@@ -77,7 +114,7 @@ func CheckOwnedCRDExistence(rv1 *bundle.RegistryV1) []error {
 }
 
 // CheckCRDResourceUniqueness checks that the bundle CRD names are unique
-func CheckCRDResourceUniqueness(rv1 *bundle.RegistryV1) []error {
+func checkCRDResourceUniqueness(rv1 *bundle.RegistryV1) []error {
 	crdsNames := sets.Set[string]{}
 	duplicateCRDNames := sets.Set[string]{}
 	for _, crd := range rv1.CRDs {
@@ -95,7 +132,7 @@ func CheckCRDResourceUniqueness(rv1 *bundle.RegistryV1) []error {
 }
 
 // CheckPackageNameNotEmpty checks that PackageName is not empty
-func CheckPackageNameNotEmpty(rv1 *bundle.RegistryV1) []error {
+func checkPackageNameNotEmpty(rv1 *bundle.RegistryV1) []error {
 	if rv1.PackageName == "" {
 		return []error{errors.New("package name is empty")}
 	}
@@ -105,7 +142,7 @@ func CheckPackageNameNotEmpty(rv1 *bundle.RegistryV1) []error {
 // CheckConversionWebhookSupport checks that if the bundle cluster service version declares conversion webhook definitions,
 // that the bundle also only supports AllNamespaces install mode. This keeps parity with OLMv0 behavior for conversion webhooks,
 // https://github.com/operator-framework/operator-lifecycle-manager/blob/dfd0b2bea85038d3c0d65348bc812d297f16b8d2/pkg/controller/install/webhook.go#L193
-func CheckConversionWebhookSupport(rv1 *bundle.RegistryV1) []error {
+func checkConversionWebhookSupport(rv1 *bundle.RegistryV1) []error {
 	var conversionWebhookNames []string
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
 		if wh.Type == v1alpha1.ConversionWebhook {
@@ -137,7 +174,7 @@ func CheckConversionWebhookSupport(rv1 *bundle.RegistryV1) []error {
 // CheckWebhookDeploymentReferentialIntegrity checks that each webhook definition in the csv
 // references an existing strategy deployment spec. Errors are sorted by strategy deployment spec name,
 // webhook type, and webhook name.
-func CheckWebhookDeploymentReferentialIntegrity(rv1 *bundle.RegistryV1) []error {
+func checkWebhookDeploymentReferentialIntegrity(rv1 *bundle.RegistryV1) []error {
 	webhooksByDeployment := map[string][]v1alpha1.WebhookDescription{}
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
 		webhooksByDeployment[wh.DeploymentName] = append(webhooksByDeployment[wh.DeploymentName], wh)
@@ -171,7 +208,7 @@ func CheckWebhookDeploymentReferentialIntegrity(rv1 *bundle.RegistryV1) []error 
 // CheckWebhookNameUniqueness checks that each webhook definition of each type (validating, mutating, or conversion)
 // has a unique name. Webhooks of different types can have the same name. Errors are sorted by webhook type
 // and name.
-func CheckWebhookNameUniqueness(rv1 *bundle.RegistryV1) []error {
+func checkWebhookNameUniqueness(rv1 *bundle.RegistryV1) []error {
 	webhookNameSetByType := map[v1alpha1.WebhookAdmissionType]sets.Set[string]{}
 	duplicateWebhooksByType := map[v1alpha1.WebhookAdmissionType]sets.Set[string]{}
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
@@ -205,7 +242,7 @@ func CheckWebhookNameUniqueness(rv1 *bundle.RegistryV1) []error {
 
 // CheckConversionWebhooksReferenceOwnedCRDs checks defined conversion webhooks reference bundle owned CRDs.
 // Errors are sorted by webhook name and CRD name.
-func CheckConversionWebhooksReferenceOwnedCRDs(rv1 *bundle.RegistryV1) []error {
+func checkConversionWebhooksReferenceOwnedCRDs(rv1 *bundle.RegistryV1) []error {
 	//nolint:prealloc
 	var conversionWebhooks []v1alpha1.WebhookDescription
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
@@ -242,7 +279,7 @@ func CheckConversionWebhooksReferenceOwnedCRDs(rv1 *bundle.RegistryV1) []error {
 }
 
 // CheckConversionWebhookCRDReferenceUniqueness checks no two (or more) conversion webhooks reference the same CRD.
-func CheckConversionWebhookCRDReferenceUniqueness(rv1 *bundle.RegistryV1) []error {
+func checkConversionWebhookCRDReferenceUniqueness(rv1 *bundle.RegistryV1) []error {
 	// collect webhooks by crd
 	crdToWh := map[string][]string{}
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
@@ -269,7 +306,7 @@ func CheckConversionWebhookCRDReferenceUniqueness(rv1 *bundle.RegistryV1) []erro
 }
 
 // CheckWebhookNameIsDNS1123SubDomain checks each webhook configuration name complies with the Kubernetes resource naming conversions
-func CheckWebhookNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
+func checkWebhookNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
 	invalidWebhooksByType := map[v1alpha1.WebhookAdmissionType]map[string][]string{}
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
 		if _, ok := invalidWebhooksByType[wh.Type]; !ok {
@@ -324,7 +361,7 @@ var forbiddenAdmissionRegistrationResources = sets.New(
 // configurations.
 // See https://github.com/operator-framework/operator-lifecycle-manager/blob/ccf0c4c91f1e7673e87f3a18947f9a1f88d48438/pkg/controller/install/webhook.go#L19
 // for more details
-func CheckWebhookRules(rv1 *bundle.RegistryV1) []error {
+func checkWebhookRules(rv1 *bundle.RegistryV1) []error {
 	var errs []error
 	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
 		// Rules are not used for conversion webhooks
@@ -352,7 +389,7 @@ func CheckWebhookRules(rv1 *bundle.RegistryV1) []error {
 
 // CheckObjectSupport checks that the non-CRD and non-CSV bundle objects are supported by the
 // registry+v1 standard
-func CheckObjectSupport(rv1 *bundle.RegistryV1) []error {
+func checkObjectSupport(rv1 *bundle.RegistryV1) []error {
 	var errs []error
 	for _, obj := range rv1.Others {
 		kind := obj.GetObjectKind().GroupVersionKind().Kind

--- a/internal/render/registryv1/validator/validator_test.go
+++ b/internal/render/registryv1/validator/validator_test.go
@@ -1,9 +1,10 @@
-package validators_test
+package validator_test
 
 import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -14,9 +15,50 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render/registryv1/validators"
+	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/regv1render/internal/render/registryv1/validator"
 	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
 )
+
+var v = validator.BundleValidator{}
+
+func validationErrorsForCheck(err error, checkName string) []*render.ValidationError {
+	if err == nil {
+		return nil
+	}
+	var result []*render.ValidationError
+	for _, e := range unwrapAll(err) {
+		var ve *render.ValidationError
+		if errors.As(e, &ve) && ve.Check == checkName {
+			result = append(result, ve)
+		}
+	}
+	return result
+}
+
+func unwrapAll(err error) []error {
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		return joined.Unwrap()
+	}
+	return []error{err}
+}
+
+func requireCheckErrors(t *testing.T, err error, checkName string, expectedMsgs []string) {
+	t.Helper()
+	ves := validationErrorsForCheck(err, checkName)
+	require.Len(t, ves, len(expectedMsgs), "expected %d %s errors, got %d", len(expectedMsgs), checkName, len(ves))
+	for i, msg := range expectedMsgs {
+		assert.Equal(t, msg, ves[i].Err.Error(), "error %d for check %s", i, checkName)
+	}
+}
+
+func toMessages(errs []error) []string {
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Error()
+	}
+	return msgs
+}
 
 func Test_CheckDeploymentSpecUniqueness(t *testing.T) {
 	for _, tc := range []struct {
@@ -66,8 +108,8 @@ func Test_CheckDeploymentSpecUniqueness(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckDeploymentSpecUniqueness(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "DeploymentSpecUniqueness", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -106,8 +148,8 @@ func Test_CheckDeploymentNameIsDNS1123SubDomain(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckDeploymentNameIsDNS1123SubDomain(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "DeploymentNameDNS1123", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -151,8 +193,8 @@ func Test_CRDResourceUniqueness(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validators.CheckCRDResourceUniqueness(tc.bundle)
-			require.Equal(t, tc.expectedErrs, err)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "CRDResourceUniqueness", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -206,8 +248,8 @@ func Test_CheckOwnedCRDExistence(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckOwnedCRDExistence(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "OwnedCRDExistence", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -232,8 +274,8 @@ func Test_CheckPackageNameNotEmpty(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckPackageNameNotEmpty(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "PackageNameNotEmpty", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -303,8 +345,8 @@ func Test_CheckWebhookSupport(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckConversionWebhookSupport(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "ConversionWebhookSupport", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -601,8 +643,8 @@ func Test_CheckWebhookRules(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckWebhookRules(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "WebhookRules", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -696,8 +738,8 @@ func Test_CheckWebhookDeploymentReferentialIntegrity(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckWebhookDeploymentReferentialIntegrity(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "WebhookDeploymentReferentialIntegrity", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -866,8 +908,8 @@ func Test_CheckWebhookNameUniqueness(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckWebhookNameUniqueness(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "WebhookNameUniqueness", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -976,8 +1018,8 @@ func Test_CheckConversionWebhooksReferenceOwnedCRDs(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckConversionWebhooksReferenceOwnedCRDs(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "ConversionWebhooksReferenceOwnedCRDs", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -1106,8 +1148,8 @@ func Test_CheckConversionWebhookCRDReferenceUniqueness(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckConversionWebhookCRDReferenceUniqueness(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "ConversionWebhookCRDReferenceUniqueness", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -1168,8 +1210,8 @@ func Test_CheckWebhookNameIsDNS1123SubDomain(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckWebhookNameIsDNS1123SubDomain(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "WebhookNameDNS1123", toMessages(tc.expectedErrs))
 		})
 	}
 }
@@ -1247,8 +1289,8 @@ func Test_CheckObjectSupport(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validators.CheckObjectSupport(tc.bundle)
-			require.Equal(t, tc.expectedErrs, errs)
+			err := v.Validate(tc.bundle)
+			requireCheckErrors(t, err, "ObjectSupport", toMessages(tc.expectedErrs))
 		})
 	}
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -13,16 +13,9 @@ import (
 	"github.com/perdasilva/regv1render/internal/bundle"
 )
 
-// BundleValidator validates a RegistryV1 bundle by executing a series of
-// checks on it and collecting any errors that were found
-type BundleValidator []func(v1 *bundle.RegistryV1) []error
-
-func (v BundleValidator) Validate(rv1 *bundle.RegistryV1) error {
-	errs := make([]error, 0, len(v))
-	for _, validator := range v {
-		errs = append(errs, validator(rv1)...)
-	}
-	return errors.Join(errs...)
+// BundleValidator validates a RegistryV1 bundle.
+type BundleValidator interface {
+	Validate(rv1 *bundle.RegistryV1) error
 }
 
 // ResourceGenerator generates resources given a registry+v1 bundle and options
@@ -126,8 +119,10 @@ type BundleRenderer struct {
 
 func (r BundleRenderer) Render(rv1 bundle.RegistryV1, installNamespace string, opts ...Option) ([]client.Object, error) {
 	// validate bundle
-	if err := r.BundleValidator.Validate(&rv1); err != nil {
-		return nil, err
+	if r.BundleValidator != nil {
+		if err := r.BundleValidator.Validate(&rv1); err != nil {
+			return nil, err
+		}
 	}
 
 	// generate bundle objects

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -29,13 +29,13 @@ func Test_BundleRenderer_NoConfig(t *testing.T) {
 	require.Empty(t, objs)
 }
 
+type failingValidator struct{ err error }
+
+func (f failingValidator) Validate(_ *bundle.RegistryV1) error { return f.err }
+
 func Test_BundleRenderer_ValidatesBundle(t *testing.T) {
 	renderer := render.BundleRenderer{
-		BundleValidator: render.BundleValidator{
-			func(v1 *bundle.RegistryV1) []error {
-				return []error{errors.New("this bundle is invalid")}
-			},
-		},
+		BundleValidator: failingValidator{err: errors.New("this bundle is invalid")},
 	}
 	objs, err := renderer.Render(bundle.RegistryV1{}, "")
 	require.Nil(t, objs)
@@ -365,22 +365,6 @@ func Test_BundleRenderer_ReturnsResourceGeneratorErrors(t *testing.T) {
 	require.Nil(t, objs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "generator error")
-}
-
-func Test_BundleValidatorCallsAllValidationFnsInOrder(t *testing.T) {
-	actual := ""
-	val := render.BundleValidator{
-		func(v1 *bundle.RegistryV1) []error {
-			actual += "h"
-			return nil
-		},
-		func(v1 *bundle.RegistryV1) []error {
-			actual += "i"
-			return nil
-		},
-	}
-	require.NoError(t, val.Validate(nil))
-	require.Equal(t, "hi", actual)
 }
 
 func Test_WithDeploymentConfig(t *testing.T) {

--- a/internal/render/validation_error.go
+++ b/internal/render/validation_error.go
@@ -1,0 +1,17 @@
+package render
+
+import "fmt"
+
+// ValidationError represents a validation failure from a specific check.
+type ValidationError struct {
+	Check string
+	Err   error
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Check, e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}

--- a/render.go
+++ b/render.go
@@ -14,9 +14,14 @@ import (
 // with all standard validators and generators.
 type BundleRenderer = render.BundleRenderer
 
-// BundleValidator is a collection of validation functions that check a
-// registry+v1 bundle for correctness before rendering.
+// BundleValidator validates a registry+v1 bundle for correctness
+// before rendering.
 type BundleValidator = render.BundleValidator
+
+// ValidationError represents a validation failure from a specific check.
+// Use errors.As to extract it from validation errors and inspect the
+// Check field to identify which validation rule failed.
+type ValidationError = render.ValidationError
 
 // ResourceGenerator is a function that generates Kubernetes resources
 // from a registry+v1 bundle and rendering options.

--- a/specs/2026-04-23-issue-17-concrete-validator/plan.md
+++ b/specs/2026-04-23-issue-17-concrete-validator/plan.md
@@ -1,0 +1,48 @@
+# Refactor Validator to Concrete Type with Structured Errors
+
+Replace the generic `BundleValidator` function-slice pattern with a concrete `Validator` struct that owns all 13 validation checks internally, returns structured `ValidationError` types, and simplifies the public API.
+
+## Task Group 1: Add ValidationError type (small)
+
+Define the structured error type in `internal/render/`.
+
+- Create `ValidationError` struct with `Check` (string) and `Err` (error) fields
+- Implement `Error()` and `Unwrap()` methods
+- Export `ValidationError` from the public API in `render.go`
+
+## Task Group 2: Refactor validator to concrete struct (medium)
+
+Replace the function-slice pattern with a concrete `Validator` struct.
+
+- Create `Validator` struct in `internal/render/registryv1/validator/`
+- Add `Validate(*bundle.RegistryV1) error` method that runs all 13 checks
+- Wrap each check's errors in `ValidationError` with the check name
+- Unexport the 13 `Check*` functions (rename to lowercase)
+- Change `BundleValidator` from function-slice type to interface in `internal/render/render.go`
+- Add nil-validator guard in `Render()` to handle zero-value `BundleRenderer{}`
+
+## Task Group 3: Update wiring and public API (small)
+
+Wire the new validator into the renderer and update the public API.
+
+- Update `BundleRenderer` struct to hold `validators.Validator` instead of `BundleValidator`
+- Update `registryv1.go` to use the new concrete `Validator`
+- Update `render.go` public API — `BundleValidator` now aliases the interface, export `ValidationError`
+- Update godoc comments
+
+## Task Group 4: Refactor tests (large)
+
+Rewrite tests to exercise `Validate()` and assert on `ValidationError`.
+
+- Refactor `validator_test.go` — tests call `Validate()` on a full `Validator`, then use `errors.As` to find specific `ValidationError` values with expected `Check` names
+- Remove `Test_BundleValidatorHasAllValidationFns` guard test
+- Verify existing regression tests pass (update if error format changes)
+- Add tests for `ValidationError` (Error(), Unwrap(), errors.As)
+
+## Task Group 5: Clean up (small)
+
+Final consistency checks.
+
+- Run `make verify`
+- Verify no exported `Check*` functions remain in validators package
+- Update CLAUDE.md if needed

--- a/specs/2026-04-23-issue-17-concrete-validator/requirements.md
+++ b/specs/2026-04-23-issue-17-concrete-validator/requirements.md
@@ -1,0 +1,30 @@
+# Requirements
+
+## Functional Requirements
+
+- A concrete `Validator` struct replaces `BundleValidator []func(*RegistryV1) []error`
+- `Validator.Validate(*RegistryV1)` runs all 13 checks and returns a joined error
+- Each validation failure is wrapped in a `ValidationError` with a `Check` field identifying which check failed
+- `ValidationError` implements `Error()` and `Unwrap()` for standard Go error handling
+- Consumers can use `errors.As(err, &ve)` to extract `ValidationError` and inspect `ve.Check`
+- All 13 existing checks produce identical validation behavior (same inputs fail/pass)
+
+## Non-Functional Requirements
+
+- **Simpler API** — consumers no longer see `BundleValidator`, `ResourceGenerator`, or the composition pattern
+- **Structured errors** — programmatic error handling via `ValidationError.Check` instead of string parsing
+- **Backward compatible rendering** — `Render()` and `DefaultRenderer` continue to work identically
+- **Testable** — tests exercise the real `Validate()` path, not individual functions in isolation
+
+## Constraints
+
+- Keep the 13 check functions in `internal/render/registryv1/validators/` — don't move them to another package
+- Validation behavior must not change — same bundles pass/fail the same way
+- Regression tests must continue to pass without golden file changes
+- `ValidationError` type must be exported from the root package for consumer use
+
+## Dependencies
+
+- Existing rendering pipeline from epic #2
+- `internal/render/registryv1/validators/validator.go` — 13 check functions
+- `internal/render/registryv1/validators/validator_test.go` — 1254 lines of tests

--- a/specs/2026-04-23-issue-17-concrete-validator/validation.md
+++ b/specs/2026-04-23-issue-17-concrete-validator/validation.md
@@ -1,0 +1,36 @@
+# Validation
+
+## Acceptance Criteria
+
+1. `BundleValidator` is now an interface (not a function-slice type)
+2. `Validator` struct exists in `internal/render/registryv1/validator/` with a `Validate()` method
+3. `ValidationError` type is exported from the root package
+4. `errors.As(err, &ve)` works on validation errors returned by `Validate()`
+5. No exported `Check*` functions remain in the validator package
+6. `Test_BundleValidatorHasAllValidationFns` guard test is removed
+7. All 13 checks still run — same bundles pass/fail identically
+8. `make verify` passes
+9. All regression tests pass without golden file changes
+
+## Test Scenarios
+
+- Call `Validate()` on a valid bundle — verify no error
+- Call `Validate()` on a bundle with duplicate deployment names — verify `ValidationError{Check: "DeploymentSpecUniqueness"}` in result
+- Call `Validate()` on a bundle with missing owned CRD — verify `ValidationError{Check: "OwnedCRDExistence"}` in result
+- Call `Validate()` with multiple validation failures — verify all `ValidationError` values are present
+- Use `errors.As` to extract `ValidationError` — verify it works
+- Use `errors.Unwrap` on `ValidationError` — verify underlying error is accessible
+- Render a bundle via `DefaultRenderer` — verify validation still runs (invalid bundle still fails)
+
+## Quality Gates
+
+- `make verify` (fmt + vet + lint + test)
+- `make build`
+- All regression tests pass unchanged
+- No exported `Check*` functions: `go doc .../validators | grep -c "^func Check"` returns 0
+
+## Manual Verification
+
+1. `go doc github.com/perdasilva/regv1render ValidationError` — verify type is documented
+2. `go doc github.com/perdasilva/regv1render` — verify `BundleValidator` is gone
+3. Run `go test -v ./internal/render/registryv1/validator/` — verify tests pass and use `Validate()`


### PR DESCRIPTION
## Summary
- Change `BundleValidator` from `[]func(*RegistryV1) []error` to a `BundleValidator` interface
- Add concrete `Validator` struct in `validators/` that runs all 13 checks internally
- Introduce `ValidationError` type with `Check` field — consumers use `errors.As` for programmatic error handling
- Unexport all 13 `Check*` functions (now internal to the Validator)
- Remove `Test_BundleValidatorHasAllValidationFns` guard test (no longer needed)
- Add nil-validator guard in `Render()` for zero-value `BundleRenderer{}`
- Rewrite validator tests to call `Validate()` and filter by `ValidationError.Check` name
- Net reduction of 837 lines

## Test Plan
- [ ] `make verify` passes
- [ ] `go test -v ./internal/render/registryv1/validators/` — all tests call `Validate()` and assert on `ValidationError`
- [ ] `go doc github.com/perdasilva/regv1render ValidationError` — type is documented
- [ ] No exported `Check*` functions: `grep "^func Check" internal/render/registryv1/validators/validator.go` returns nothing
- [ ] All regression tests pass unchanged

Closes #17