### PR TITLE
feat: add secret certificate provider with optional cert/key data

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,30 @@ crane export quay.io/my/bundle:v1 - | rv1 render --config render.yaml
 Config file format (`render.yaml`):
 
 ```yaml
-providedAPIsClusterRoles: true
 certificateProvider:
-  type: cert-manager  # or: openshift-service-ca, none
+  type: cert-manager  # or: openshift-service-ca, secret, none
 deploymentConfig:
   nodeSelector:
     kubernetes.io/os: linux
 ```
+
+The `secret` provider generates a `kubernetes.io/tls` Secret with optional cert/key data:
+
+```yaml
+certificateProvider:
+  type: secret
+  secret:
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
+
+If `cert` and `key` are omitted, an empty Secret is rendered so you can populate it externally (Vault, cert-manager ExternalSecret, etc.).
 
 ## OLMv0 Compatibility
 

--- a/certproviders.go
+++ b/certproviders.go
@@ -1,8 +1,0 @@
-package regv1render
-
-import (
-	"github.com/perdasilva/regv1render/internal/render/certproviders"
-)
-
-type certManagerProvider = certproviders.CertManagerCertificateProvider
-type openShiftServiceCAProvider = certproviders.OpenshiftServiceCaCertificateProvider

--- a/cmd/rv1/render.go
+++ b/cmd/rv1/render.go
@@ -28,13 +28,20 @@ const (
 	certProviderNone               = "none"
 	certProviderCertManager        = "cert-manager"
 	certProviderOpenShiftServiceCA = "openshift-service-ca"
+	certProviderSecret             = "secret"
 )
 
 type certificateProviderConfig struct {
-	Type string `json:"type"`
+	Type   string                `json:"type"`
+	Secret *secretProviderConfig `json:"secret,omitempty"`
 }
 
-var validCertProviderTypes = []string{certProviderNone, certProviderCertManager, certProviderOpenShiftServiceCA}
+type secretProviderConfig struct {
+	Cert string `json:"cert"`
+	Key  string `json:"key"`
+}
+
+var validCertProviderTypes = []string{certProviderNone, certProviderCertManager, certProviderOpenShiftServiceCA, certProviderSecret}
 
 func (c *certificateProviderConfig) validate() error {
 	if c == nil || c.Type == "" || c.Type == certProviderNone {
@@ -69,7 +76,7 @@ Namespace modes (controlled by --watch-namespace):
 The --config flag accepts a YAML file with renderer options:
   providedAPIsClusterRoles, deploymentConfig, and
   certificateProvider (type: cert-manager, openshift-service-ca,
-  or none).
+  secret, or none).
 
 Examples:
   # Render with AllNamespaces (default)
@@ -153,6 +160,13 @@ func buildRenderer(cfg renderConfig) *regv1render.Renderer {
 			b.WithCertificateProvider(regv1render.CertManagerProvider{})
 		case certProviderOpenShiftServiceCA:
 			b.WithCertificateProvider(regv1render.OpenShiftServiceCAProvider{})
+		case certProviderSecret:
+			provider := regv1render.SecretCertProvider{}
+			if p.Secret != nil {
+				provider.Cert = []byte(p.Secret.Cert)
+				provider.Key = []byte(p.Secret.Key)
+			}
+			b.WithCertificateProvider(provider)
 		}
 	}
 	return b.Build()

--- a/cmd/rv1/render_test.go
+++ b/cmd/rv1/render_test.go
@@ -192,3 +192,50 @@ func TestCertificateProviderConfig_CertManagerWithWebhookBundle(t *testing.T) {
 	output := buf.String()
 	assert.Contains(t, output, "apiVersion:")
 }
+
+func TestCertificateProviderConfig_Secret(t *testing.T) {
+	cfgContent := `
+certificateProvider:
+  type: secret
+`
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0600))
+
+	cfg, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.CertificateProvider)
+	assert.Equal(t, "secret", cfg.CertificateProvider.Type)
+	require.NoError(t, cfg.CertificateProvider.validate())
+
+	renderer := buildRenderer(cfg)
+	assert.NotNil(t, renderer)
+}
+
+func TestCertificateProviderConfig_SecretWithData(t *testing.T) {
+	cfgContent := `
+certificateProvider:
+  type: secret
+  secret:
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      test-cert-data
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      test-key-data
+      -----END PRIVATE KEY-----
+`
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0600))
+
+	cfg, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.CertificateProvider)
+	assert.Equal(t, "secret", cfg.CertificateProvider.Type)
+	require.NotNil(t, cfg.CertificateProvider.Secret)
+	assert.Contains(t, cfg.CertificateProvider.Secret.Cert, "test-cert-data")
+	assert.Contains(t, cfg.CertificateProvider.Secret.Key, "test-key-data")
+
+	renderer := buildRenderer(cfg)
+	assert.NotNil(t, renderer)
+}

--- a/internal/render/certproviders/secret.go
+++ b/internal/render/certproviders/secret.go
@@ -1,0 +1,60 @@
+package certproviders
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/perdasilva/regv1render/internal/render"
+)
+
+var _ render.CertificateProvider = (*SecretCertProvider)(nil)
+
+// SecretCertProvider generates a kubernetes.io/tls Secret for
+// webhook TLS. If Cert and Key are empty, the Secret is created with
+// empty data so users can populate it externally.
+type SecretCertProvider struct {
+	Cert []byte
+	Key  []byte
+}
+
+func (p SecretCertProvider) InjectCABundle(_ client.Object, _ render.CertificateProvisionerConfig) error {
+	return nil
+}
+
+func (p SecretCertProvider) AdditionalObjects(cfg render.CertificateProvisionerConfig) ([]unstructured.Unstructured, error) {
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.CertName,
+			Namespace: cfg.Namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       p.Cert,
+			corev1.TLSPrivateKeyKey: p.Key,
+		},
+	}
+
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	u := unstructured.Unstructured{Object: obj}
+	u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	return []unstructured.Unstructured{u}, nil
+}
+
+func (p SecretCertProvider) GetCertSecretInfo(cfg render.CertificateProvisionerConfig) render.CertSecretInfo {
+	return render.CertSecretInfo{
+		SecretName:     cfg.CertName,
+		CertificateKey: corev1.TLSCertKey,
+		PrivateKeyKey:  corev1.TLSPrivateKeyKey,
+	}
+}

--- a/internal/render/certproviders/secret_test.go
+++ b/internal/render/certproviders/secret_test.go
@@ -1,0 +1,77 @@
+package certproviders_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/regv1render/internal/render/certproviders"
+)
+
+func TestSecretCertProvider_InjectCABundle(t *testing.T) {
+	p := certproviders.SecretCertProvider{}
+	err := p.InjectCABundle(nil, render.CertificateProvisionerConfig{})
+	require.NoError(t, err)
+}
+
+func TestSecretCertProvider_AdditionalObjects_EmptyData(t *testing.T) {
+	p := certproviders.SecretCertProvider{}
+	cfg := render.CertificateProvisionerConfig{
+		CertName:  "test-cert",
+		Namespace: "test-ns",
+	}
+
+	objs, err := p.AdditionalObjects(cfg)
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+
+	secret := objs[0]
+	assert.Equal(t, "Secret", secret.GetKind())
+	assert.Equal(t, "test-cert", secret.GetName())
+	assert.Equal(t, "test-ns", secret.GetNamespace())
+
+	secretType, _, _ := unstructured.NestedString(secret.Object, "type")
+	assert.Equal(t, string(corev1.SecretTypeTLS), secretType)
+
+	data, _, _ := unstructured.NestedMap(secret.Object, "data")
+	assert.Contains(t, data, "tls.crt")
+	assert.Contains(t, data, "tls.key")
+}
+
+func TestSecretCertProvider_AdditionalObjects_WithData(t *testing.T) {
+	cert := []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----")
+	key := []byte("-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----")
+
+	p := certproviders.SecretCertProvider{
+		Cert: cert,
+		Key:  key,
+	}
+	cfg := render.CertificateProvisionerConfig{
+		CertName:  "my-cert",
+		Namespace: "my-ns",
+	}
+
+	objs, err := p.AdditionalObjects(cfg)
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+
+	secret := objs[0]
+	assert.Equal(t, "my-cert", secret.GetName())
+	assert.Equal(t, "my-ns", secret.GetNamespace())
+}
+
+func TestSecretCertProvider_GetCertSecretInfo(t *testing.T) {
+	p := certproviders.SecretCertProvider{}
+	cfg := render.CertificateProvisionerConfig{
+		CertName: "test-cert",
+	}
+
+	info := p.GetCertSecretInfo(cfg)
+	assert.Equal(t, "test-cert", info.SecretName)
+	assert.Equal(t, "tls.crt", info.CertificateKey)
+	assert.Equal(t, "tls.key", info.PrivateKeyKey)
+}

--- a/render.go
+++ b/render.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/perdasilva/regv1render/internal/bundle"
 	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/regv1render/internal/render/certproviders"
 	"github.com/perdasilva/regv1render/internal/render/registryv1"
 )
 
@@ -30,10 +31,16 @@ type ValidationError = render.ValidationError
 type RegistryV1 = bundle.RegistryV1
 
 // CertManagerProvider is a CertificateProvider that uses cert-manager.
-type CertManagerProvider = certManagerProvider
+type CertManagerProvider = certproviders.CertManagerCertificateProvider
 
 // OpenShiftServiceCAProvider is a CertificateProvider that uses OpenShift service-ca.
-type OpenShiftServiceCAProvider = openShiftServiceCAProvider
+type OpenShiftServiceCAProvider = certproviders.OpenshiftServiceCaCertificateProvider
+
+// SecretCertProvider is a CertificateProvider that generates a
+// kubernetes.io/tls Secret for webhook TLS. If Cert and Key are
+// empty, the Secret is created with empty data so users can
+// populate it externally (Vault, manual, etc.).
+type SecretCertProvider = certproviders.SecretCertProvider
 
 // RendererBuilder constructs a Renderer using fluent method chaining.
 type RendererBuilder struct {

--- a/specs/2026-04-23-issue-19-secret-cert-provider/plan.md
+++ b/specs/2026-04-23-issue-19-secret-cert-provider/plan.md
@@ -1,0 +1,36 @@
+# Secret Certificate Provider
+
+Add a "secret" CertificateProvider that generates a `kubernetes.io/tls` Secret with optional user-provided cert/key data. Extend the CLI config's `certificateProvider` discriminated union with the `secret` type and nested config.
+
+## Task Group 1: Implement SecretCertProvider (medium)
+
+Create the provider in `internal/render/certproviders/`.
+
+- Create `SecretCertProvider` struct with `Cert []byte` and `Key []byte` fields
+- `InjectCABundle` — no-op (return nil)
+- `AdditionalObjects` — return a `kubernetes.io/tls` Secret with `tls.crt`/`tls.key` data (empty if not provided)
+- `GetCertSecretInfo` — return the secret name and key names (`tls.crt`, `tls.key`)
+- Export `SecretCertProvider` type from `render.go` (direct alias, no indirection)
+- Remove `certproviders.go` — all provider type exports consolidated in `render.go`
+
+## Task Group 2: Update CLI config (small)
+
+Extend the discriminated union to support the `secret` type with nested config.
+
+- Add `Secret *secretProviderConfig` field to `certificateProviderConfig` struct
+- Define `secretProviderConfig` with `Cert string` and `Key string` fields
+- Add `"secret"` to `validCertProviderTypes`
+- Wire `secret` type in `buildRenderer` to create `SecretCertProvider` with cert/key data
+- Add `certProviderSecret` constant
+
+## Task Group 3: Add tests (medium)
+
+- Unit tests for `SecretCertProvider`: empty data, provided data, secret type/name/keys
+- CLI config tests: parse secret config with cert/key, parse secret config without cert/key
+- Regression test: render webhook bundle with secret provider, verify Secret object in output (11 golden files)
+
+## Task Group 4: Documentation (small)
+
+- Update README with detailed secret provider config example (with and without cert/key data)
+- Update `rv1 render --help` to mention secret provider
+- Update godoc on `SecretCertProvider`

--- a/specs/2026-04-23-issue-19-secret-cert-provider/requirements.md
+++ b/specs/2026-04-23-issue-19-secret-cert-provider/requirements.md
@@ -1,0 +1,29 @@
+# Requirements
+
+## Functional Requirements
+
+- `SecretCertificateProvider` implements the `CertificateProvider` interface
+- `InjectCABundle` is a no-op (returns nil)
+- `AdditionalObjects` returns a `kubernetes.io/tls` Secret with `tls.crt` and `tls.key` data fields
+- If cert/key data is provided, the Secret contains that data; if not, the fields are empty
+- `GetCertSecretInfo` returns the secret name and key names (`tls.crt`, `tls.key`)
+- CLI config supports `certificateProvider: { type: secret }` with optional nested `secret: { cert: ..., key: ... }`
+- The existing generator mounts the secret into webhook deployments (no changes needed)
+
+## Non-Functional Requirements
+
+- **Consistent with existing providers** — follows the same pattern as CertManager and OpenShiftServiceCA providers
+- **Backward compatible** — existing config files continue to work unchanged
+- **Well-tested** — unit tests for the provider, CLI config tests, regression test with webhook bundle
+
+## Constraints
+
+- Do not modify the `CertificateProvider` interface
+- Do not modify existing providers (CertManager, OpenShiftServiceCA)
+- Keep the provider stateless except for the cert/key data it holds
+
+## Dependencies
+
+- `CertificateProvider` interface from `internal/render/certprovider.go`
+- `CertProviderResourceGenerator` (already handles Secret mounting)
+- Discriminated union config from #15

--- a/specs/2026-04-23-issue-19-secret-cert-provider/validation.md
+++ b/specs/2026-04-23-issue-19-secret-cert-provider/validation.md
@@ -1,0 +1,36 @@
+# Validation
+
+## Acceptance Criteria
+
+1. `SecretCertificateProvider{}` implements `CertificateProvider` interface
+2. `AdditionalObjects` produces a `kubernetes.io/tls` Secret with correct keys
+3. With cert/key data provided, the Secret contains that data
+4. Without cert/key data, the Secret has empty `tls.crt`/`tls.key`
+5. `InjectCABundle` returns nil (no-op)
+6. CLI config `certificateProvider: { type: secret }` works
+7. CLI config `certificateProvider: { type: secret, secret: { cert: ..., key: ... } }` works
+8. `make verify` passes
+9. Regression test with webhook bundle + secret provider passes
+
+## Test Scenarios
+
+- Create `SecretCertificateProvider{}` with no data, call `AdditionalObjects` — verify Secret with empty data
+- Create `SecretCertificateProvider{Cert: ..., Key: ...}` with data, call `AdditionalObjects` — verify Secret with provided data
+- Verify Secret type is `kubernetes.io/tls`
+- Verify `InjectCABundle` returns nil
+- Verify `GetCertSecretInfo` returns correct secret name and key names
+- Parse CLI config with `type: secret` — verify provider is created
+- Parse CLI config with `type: secret` and cert/key data — verify data flows to provider
+- Render webhook bundle with secret provider — verify Secret appears in output
+
+## Quality Gates
+
+- `make verify` (fmt + vet + lint + test)
+- `make build`
+- All existing tests and regression tests pass unchanged
+
+## Manual Verification
+
+1. Create config with `certificateProvider: { type: secret }`
+2. Render webhook bundle: `tar -cf - -C test/regression/testdata/bundles/webhook-operator.v0.0.5 . | bin/rv1 render --install-namespace test-ns --config config.yaml`
+3. Verify a `kubernetes.io/tls` Secret appears in the output

--- a/test/regression/generate-manifests.go
+++ b/test/regression/generate-manifests.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/perdasilva/regv1render/internal/bundle/source"
 	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/regv1render/internal/render/certproviders"
 	"github.com/perdasilva/regv1render/internal/render/registryv1"
 )
 
@@ -235,6 +236,14 @@ func main() {
 			testCaseName:     "with-provided-apis-clusterroles",
 			renderOpts: []render.RenderOption{
 				render.WithProvidedAPIsClusterRoles(),
+			},
+		}, {
+			name:             "WithSecretCertProvider",
+			installNamespace: "webhook-system",
+			bundle:           "webhook-operator.v0.0.5",
+			testCaseName:     "with-secret-cert-provider",
+			configureBuilder: func(b *render.RendererBuilder) {
+				b.WithCertificateProvider(certproviders.SecretCertProvider{})
 			},
 		},
 	} {

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/00_clusterrole_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/00_clusterrole_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve
+rules:
+- apiGroups:
+  - webhook.operators.coreos.io
+  resources:
+  - webhooktests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - webhook.operators.coreos.io
+  resources:
+  - webhooktests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - webhook.operators.coreos.io
+  resources:
+  - webhooktests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/01_clusterrole_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/01_clusterrole_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/02_clusterrolebinding_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/02_clusterrolebinding_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve
+subjects:
+- kind: ServiceAccount
+  name: webhook-operator-controller-manager
+  namespace: webhook-system

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/03_clusterrolebinding_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/03_clusterrolebinding_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3
+subjects:
+- kind: ServiceAccount
+  name: webhook-operator-controller-manager
+  namespace: webhook-system

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/04_customresourcedefinition_webhooktests.webhook.operators.coreos.io.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/04_customresourcedefinition_webhooktests.webhook.operators.coreos.io.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: webhook-operator-system/webhook-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: webhooktests.webhook.operators.coreos.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-operator-controller-manager-service
+          namespace: webhook-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: webhook.operators.coreos.io
+  names:
+    kind: WebhookTest
+    listKind: WebhookTestList
+    plural: webhooktests
+    singular: webhooktest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: WebhookTest is the Schema for the webhooktests API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of WebhookTest
+            properties:
+              mutate:
+                description: Mutate is a field that will be set to true by the mutating
+                  webhook.
+                type: boolean
+              valid:
+                description: Valid must be set to true or the validation webhook will
+                  reject the resource.
+                type: boolean
+            required:
+            - valid
+            type: object
+          status:
+            description: status defines the observed state of WebhookTest
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the WebhookTest resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: WebhookTest is the Schema for the webhooktests API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of WebhookTest
+            properties:
+              conversion:
+                description: Conversion is an example field of WebhookTest. Edit WebhookTest_types.go
+                  to remove/update
+                properties:
+                  mutate:
+                    description: Mutate is a field that will be set to true by the
+                      mutating webhook.
+                    type: boolean
+                  valid:
+                    description: Valid must be set to true or the validation webhook
+                      will reject the resource.
+                    type: boolean
+                required:
+                - valid
+                type: object
+            required:
+            - conversion
+            type: object
+          status:
+            description: status defines the observed state of WebhookTest
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the WebhookTest resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/05_deployment_webhook-operator-controller-manager.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/05_deployment_webhook-operator-controller-manager.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: webhook-operator
+    control-plane: controller-manager
+  name: webhook-operator-controller-manager
+  namespace: webhook-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook-operator
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "webhook.operators.coreos.io/v1",
+              "kind": "WebhookTest",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "webhook-operator"
+                },
+                "name": "webhooktest-sample"
+              },
+              "spec": null
+            },
+            {
+              "apiVersion": "webhook.operators.coreos.io/v2",
+              "kind": "WebhookTest",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "webhook-operator"
+                },
+                "name": "webhooktest-sample"
+              },
+              "spec": null
+            }
+          ]
+        capabilities: Basic Install
+        kubectl.kubernetes.io/default-container: manager
+        olm.targetNamespaces: ""
+        operators.operatorframework.io/builder: operator-sdk-v1.41.1
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      labels:
+        app.kubernetes.io/name: webhook-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        command:
+        - /manager
+        image: quay.io/olmtest/webhook-operator:v0.0.5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-cert
+        - mountPath: /apiserver.local.config/certificates
+          name: apiservice-cert
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: webhook-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: webhook-cert
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          secretName: webhook-operator-controller-manager-service-cert
+      - name: apiservice-cert
+        secret:
+          items:
+          - key: tls.crt
+            path: apiserver.crt
+          - key: tls.key
+            path: apiserver.key
+          secretName: webhook-operator-controller-manager-service-cert
+status: {}

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/06_mutatingwebhookconfiguration_mwebhooktest-v1.kb.io.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/06_mutatingwebhookconfiguration_mwebhooktest-v1.kb.io.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mwebhooktest-v1.kb.io
+  namespace: webhook-system
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-operator-controller-manager-service
+      namespace: webhook-system
+      path: /mutate-webhook-operators-coreos-io-v1-webhooktest
+      port: 443
+  failurePolicy: Fail
+  name: mwebhooktest-v1.kb.io
+  rules:
+  - apiGroups:
+    - webhook.operators.coreos.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - webhooktests
+  sideEffects: None

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/07_secret_webhook-operator-controller-manager-service-cert.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/07_secret_webhook-operator-controller-manager-service-cert.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  tls.crt: null
+  tls.key: null
+kind: Secret
+metadata:
+  name: webhook-operator-controller-manager-service-cert
+  namespace: webhook-system
+type: kubernetes.io/tls

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/08_service_webhook-operator-controller-manager-service.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/08_service_webhook-operator-controller-manager-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-operator-controller-manager-service
+  namespace: webhook-system
+spec:
+  ports:
+  - name: "443"
+    port: 443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: webhook-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/09_serviceaccount_webhook-operator-controller-manager.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/09_serviceaccount_webhook-operator-controller-manager.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhook-operator-controller-manager
+  namespace: webhook-system

--- a/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/10_validatingwebhookconfiguration_vwebhooktest-v1.kb.io.yaml
+++ b/test/regression/testdata/expected-manifests/webhook-operator.v0.0.5/with-secret-cert-provider/10_validatingwebhookconfiguration_vwebhooktest-v1.kb.io.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vwebhooktest-v1.kb.io
+  namespace: webhook-system
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-operator-controller-manager-service
+      namespace: webhook-system
+      path: /validate-webhook-operators-coreos-io-v1-webhooktest
+      port: 443
+  failurePolicy: Fail
+  name: vwebhooktest-v1.kb.io
+  rules:
+  - apiGroups:
+    - webhook.operators.coreos.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - webhooktests
+  sideEffects: None


### PR DESCRIPTION
## Summary
- Add `SecretCertificateProvider` that generates a `kubernetes.io/tls` Secret for webhook TLS
- If cert/key data is provided in config, the Secret contains it; otherwise renders empty data for external population
- Extend CLI config discriminated union with `type: secret` and nested `secret.cert`/`secret.key` fields
- Export `SecretProvider` type from root package
- 4 unit tests for the provider + 2 CLI config tests
- Regression test with webhook bundle + secret provider (11 golden files)
- Updated README and help text to include `secret` provider type

## Test Plan
- [ ] `make verify` passes
- [ ] `go test -v ./internal/render/certproviders/ -run Secret` — all 4 tests pass
- [ ] `go test -v ./cmd/rv1/ -run Secret` — both config tests pass
- [ ] Regression test with webhook bundle passes
- [ ] Config with `type: secret` renders a TLS Secret in output

Closes #19