### PR TITLE
chore: rename module to rv1 and remove top-level Render function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ issues:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/perdasilva/regv1render
+    local-prefixes: github.com/perdasilva/rv1
   revive:
     rules:
       - name: blank-imports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# regv1render
+# rv1
 
 A standalone Go library for rendering OLM registry+v1 bundles to plain Kubernetes manifests. Extracted from `operator-framework/operator-controller/internal/rukpak/render` and compatible with `operator-framework/operator-lifecycle-manager` rendering behavior.
 
 ## Architecture
 
 ```
-*.go           Public API at repo root — consumers import github.com/perdasilva/regv1render
+*.go           Public API at repo root — consumers import github.com/perdasilva/rv1
 testdata/      Test fixtures (ignored by go build)
 internal/      Non-public implementation details (not importable by consumers)
   bundle/      RegistryV1 bundle type, annotations, and source loading (fs.FS)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to regv1render
+# Contributing to rv1
 
 ## Prerequisites
 
@@ -8,8 +8,8 @@
 ## Getting Started
 
 ```bash
-git clone https://github.com/perdasilva/regv1render.git
-cd regv1render
+git clone https://github.com/perdasilva/rv1.git
+cd rv1
 make verify   # run the full quality gate (fmt + vet + lint + test)
 make build    # build the rv1 CLI binary
 ```
@@ -69,7 +69,7 @@ bingo get <tool-module-path>
 ## Project Structure
 
 ```
-*.go           Public API (consumers import github.com/perdasilva/regv1render)
+*.go           Public API (consumers import github.com/perdasilva/rv1)
 internal/      Private implementation (render engine, bundle types, utilities)
 cmd/rv1/       CLI tool
 test/          Regression tests with golden-file fixtures

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint: $(GOLANGCI_LINT)
 
 fmt: $(GOIMPORTS)
 	gofmt -w .
-	$(GOIMPORTS) -w -local github.com/perdasilva/regv1render .
+	$(GOIMPORTS) -w -local github.com/perdasilva/rv1 .
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ import (
 
 func main() {
 	// Load a bundle from a directory on disk
-	bundleSource := rv1.FromFS(os.DirFS("path/to/bundle"))
-	rv1, err := bundleSource.GetBundle()
+	source := rv1.FromFS(os.DirFS("path/to/bundle"))
+	bundle, err := source.GetBundle()
 	if err != nil {
 		panic(err)
 	}
 
-	// Render the bundle to plain Kubernetes manifests
-	objects, err := rv1.Render(rv1, "my-namespace",
+	// Build a renderer and render the bundle
+	renderer := rv1.NewRendererBuilder().Build()
+	objects, err := renderer.Render(bundle, "my-namespace",
 		rv1.WithTargetNamespaces("watch-ns"),
 	)
 	if err != nil {
@@ -42,6 +43,17 @@ func main() {
 
 	fmt.Printf("Rendered %d objects\n", len(objects))
 }
+```
+
+The builder supports certificate providers for webhook TLS and deployment customization:
+
+```go
+renderer := rv1.NewRendererBuilder().
+    WithCertificateProvider(rv1.CertManagerProvider{}).
+    WithDeploymentConfig(&rv1.DeploymentConfig{
+        NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+    }).
+    Build()
 ```
 
 ### CLI
@@ -101,7 +113,8 @@ The library includes opt-in support for rendering behaviors from the original [o
 Use `WithProvidedAPIsClusterRoles()` to generate aggregated admin/edit/view ClusterRoles for each owned CRD, matching OLMv0 behavior:
 
 ```go
-objs, err := rv1.Render(rv1, "my-namespace",
+renderer := rv1.NewRendererBuilder().Build()
+objs, err := renderer.Render(bundle, "my-namespace",
     rv1.WithProvidedAPIsClusterRoles(),
 )
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# regv1render
+# rv1
 
 A standalone Go library for rendering OLM registry+v1 bundles to plain Kubernetes manifests.
 
@@ -9,7 +9,7 @@ Extracted from [`operator-framework/operator-controller/internal/rukpak/render`]
 ## Install
 
 ```bash
-go get github.com/perdasilva/regv1render
+go get github.com/perdasilva/rv1
 ```
 
 ## Usage
@@ -21,20 +21,20 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/perdasilva/regv1render"
+	"github.com/perdasilva/rv1"
 )
 
 func main() {
 	// Load a bundle from a directory on disk
-	bundleSource := regv1render.FromFS(os.DirFS("path/to/bundle"))
+	bundleSource := rv1.FromFS(os.DirFS("path/to/bundle"))
 	rv1, err := bundleSource.GetBundle()
 	if err != nil {
 		panic(err)
 	}
 
 	// Render the bundle to plain Kubernetes manifests
-	objects, err := regv1render.Render(rv1, "my-namespace",
-		regv1render.WithTargetNamespaces("watch-ns"),
+	objects, err := rv1.Render(rv1, "my-namespace",
+		rv1.WithTargetNamespaces("watch-ns"),
 	)
 	if err != nil {
 		panic(err)
@@ -49,7 +49,7 @@ func main() {
 The `rv1` CLI renders bundles from the command line. It reads a bundle tar stream from stdin:
 
 ```bash
-go install github.com/perdasilva/regv1render/cmd/rv1@latest
+go install github.com/perdasilva/rv1/cmd/rv1@latest
 
 # Render from a container image using docker
 docker export $(docker create quay.io/my/bundle:v1 /bin/true) | rv1 render --install-namespace my-ns
@@ -101,8 +101,8 @@ The library includes opt-in support for rendering behaviors from the original [o
 Use `WithProvidedAPIsClusterRoles()` to generate aggregated admin/edit/view ClusterRoles for each owned CRD, matching OLMv0 behavior:
 
 ```go
-objs, err := regv1render.Render(rv1, "my-namespace",
-    regv1render.WithProvidedAPIsClusterRoles(),
+objs, err := rv1.Render(rv1, "my-namespace",
+    rv1.WithProvidedAPIsClusterRoles(),
 )
 ```
 

--- a/cmd/rv1/helpers_test.go
+++ b/cmd/rv1/helpers_test.go
@@ -6,15 +6,15 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render"
+	"github.com/perdasilva/rv1"
 )
 
-func fromFSHelper(t *testing.T, fsys fs.FS) regv1render.BundleSource {
+func fromFSHelper(t *testing.T, fsys fs.FS) rv1.BundleSource {
 	t.Helper()
-	return regv1render.FromFS(fsys)
+	return rv1.FromFS(fsys)
 }
 
-func renderBundle(source regv1render.BundleSource, installNamespace string, watchNamespaces []string, cfg renderConfig) ([]client.Object, error) {
+func renderBundle(source rv1.BundleSource, installNamespace string, watchNamespaces []string, cfg renderConfig) ([]client.Object, error) {
 	rv1, err := source.GetBundle()
 	if err != nil {
 		return nil, err

--- a/cmd/rv1/render.go
+++ b/cmd/rv1/render.go
@@ -15,13 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/perdasilva/regv1render"
+	"github.com/perdasilva/rv1"
 )
 
 type renderConfig struct {
-	ProvidedAPIsClusterRoles bool                          `json:"providedAPIsClusterRoles"`
-	DeploymentConfig         *regv1render.DeploymentConfig `json:"deploymentConfig,omitempty"`
-	CertificateProvider      *certificateProviderConfig    `json:"certificateProvider,omitempty"`
+	ProvidedAPIsClusterRoles bool                       `json:"providedAPIsClusterRoles"`
+	DeploymentConfig         *rv1.DeploymentConfig      `json:"deploymentConfig,omitempty"`
+	CertificateProvider      *certificateProviderConfig `json:"certificateProvider,omitempty"`
 }
 
 const (
@@ -110,7 +110,7 @@ Examples:
 				return fmt.Errorf("reading bundle from stdin: %w", err)
 			}
 
-			source := regv1render.FromFS(bundleFS)
+			source := rv1.FromFS(bundleFS)
 			rv1, err := source.GetBundle()
 			if err != nil {
 				return fmt.Errorf("parsing bundle: %w", err)
@@ -149,19 +149,19 @@ func loadConfig(path string) (renderConfig, error) {
 	return cfg, nil
 }
 
-func buildRenderer(cfg renderConfig) *regv1render.Renderer {
-	b := regv1render.NewRendererBuilder()
+func buildRenderer(cfg renderConfig) *rv1.Renderer {
+	b := rv1.NewRendererBuilder()
 	if cfg.DeploymentConfig != nil {
 		b.WithDeploymentConfig(cfg.DeploymentConfig)
 	}
 	if p := cfg.CertificateProvider; p != nil {
 		switch p.Type {
 		case certProviderCertManager:
-			b.WithCertificateProvider(regv1render.CertManagerProvider{})
+			b.WithCertificateProvider(rv1.CertManagerProvider{})
 		case certProviderOpenShiftServiceCA:
-			b.WithCertificateProvider(regv1render.OpenShiftServiceCAProvider{})
+			b.WithCertificateProvider(rv1.OpenShiftServiceCAProvider{})
 		case certProviderSecret:
-			provider := regv1render.SecretCertProvider{}
+			provider := rv1.SecretCertProvider{}
 			if p.Secret != nil {
 				provider.Cert = []byte(p.Secret.Cert)
 				provider.Key = []byte(p.Secret.Key)
@@ -172,13 +172,13 @@ func buildRenderer(cfg renderConfig) *regv1render.Renderer {
 	return b.Build()
 }
 
-func buildRenderOptions(cfg renderConfig, watchNamespaces []string) []regv1render.RenderOption {
-	var opts []regv1render.RenderOption
+func buildRenderOptions(cfg renderConfig, watchNamespaces []string) []rv1.RenderOption {
+	var opts []rv1.RenderOption
 	if len(watchNamespaces) > 0 {
-		opts = append(opts, regv1render.WithTargetNamespaces(watchNamespaces...))
+		opts = append(opts, rv1.WithTargetNamespaces(watchNamespaces...))
 	}
 	if cfg.ProvidedAPIsClusterRoles {
-		opts = append(opts, regv1render.WithProvidedAPIsClusterRoles())
+		opts = append(opts, rv1.WithProvidedAPIsClusterRoles())
 	}
 	return opts
 }

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Package regv1render renders OLM registry+v1 bundles to plain Kubernetes manifests.
+// Package rv1 renders OLM registry+v1 bundles to plain Kubernetes manifests.
 //
 // This library is extracted from the operator-framework/operator-controller rendering
 // pipeline and is compatible with the operator-framework/operator-lifecycle-manager
@@ -6,20 +6,20 @@
 //
 // The simplest way to render a bundle is with the top-level Render function:
 //
-//	objs, err := regv1render.Render(rv1, "install-namespace")
+//	objs, err := rv1.Render(bundle, "install-namespace")
 //
 // For more control, use the builder to create a configured Renderer:
 //
-//	r := regv1render.NewRendererBuilder().
-//	    WithCertificateProvider(regv1render.CertManagerProvider{}).
+//	r := rv1.NewRendererBuilder().
+//	    WithCertificateProvider(rv1.CertManagerProvider{}).
 //	    Build()
-//	objs, err := r.Render(rv1, "install-namespace",
-//	    regv1render.WithTargetNamespaces("watch-ns"),
-//	    regv1render.WithProvidedAPIsClusterRoles(),
+//	objs, err := r.Render(bundle, "install-namespace",
+//	    rv1.WithTargetNamespaces("watch-ns"),
+//	    rv1.WithProvidedAPIsClusterRoles(),
 //	)
 //
 // Bundles can be loaded from a filesystem using FromFS:
 //
-//	source := regv1render.FromFS(os.DirFS("path/to/bundle"))
-//	rv1, err := source.GetBundle()
-package regv1render
+//	source := rv1.FromFS(os.DirFS("path/to/bundle"))
+//	bundle, err := source.GetBundle()
+package rv1

--- a/doc.go
+++ b/doc.go
@@ -4,16 +4,17 @@
 // pipeline and is compatible with the operator-framework/operator-lifecycle-manager
 // rendering behavior.
 //
-// The simplest way to render a bundle is with the top-level Render function:
+// Create a Renderer using the builder:
 //
-//	objs, err := rv1.Render(bundle, "install-namespace")
+//	renderer := rv1.NewRendererBuilder().Build()
+//	objs, err := renderer.Render(bundle, "install-namespace")
 //
-// For more control, use the builder to create a configured Renderer:
+// Configure certificate providers and render options:
 //
-//	r := rv1.NewRendererBuilder().
+//	renderer := rv1.NewRendererBuilder().
 //	    WithCertificateProvider(rv1.CertManagerProvider{}).
 //	    Build()
-//	objs, err := r.Render(bundle, "install-namespace",
+//	objs, err := renderer.Render(bundle, "install-namespace",
 //	    rv1.WithTargetNamespaces("watch-ns"),
 //	    rv1.WithProvidedAPIsClusterRoles(),
 //	)

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-package regv1render_test
+package rv1_test
 
 import (
 	"fmt"
@@ -9,11 +9,11 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render"
+	regv1 "github.com/perdasilva/rv1"
 )
 
-func exampleBundle() regv1render.RegistryV1 {
-	return regv1render.RegistryV1{
+func exampleBundle() regv1.RegistryV1 {
+	return regv1.RegistryV1{
 		PackageName: "my-operator",
 		CSV: v1alpha1.ClusterServiceVersion{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-operator.v1.0.0"},
@@ -57,7 +57,7 @@ func exampleBundle() regv1render.RegistryV1 {
 func ExampleRender() {
 	rv1 := exampleBundle()
 
-	objs, err := regv1render.Render(rv1, "operators")
+	objs, err := regv1.Render(rv1, "operators")
 	if err != nil {
 		panic(err)
 	}
@@ -70,8 +70,8 @@ func ExampleRender() {
 func ExampleRender_withTargetNamespaces() {
 	rv1 := exampleBundle()
 
-	objs, err := regv1render.Render(rv1, "operators",
-		regv1render.WithTargetNamespaces("watch-ns"),
+	objs, err := regv1.Render(rv1, "operators",
+		regv1.WithTargetNamespaces("watch-ns"),
 	)
 	if err != nil {
 		panic(err)
@@ -85,8 +85,8 @@ func ExampleRender_withTargetNamespaces() {
 func ExampleRender_withProvidedAPIsClusterRoles() {
 	rv1 := exampleBundle()
 
-	objs, err := regv1render.Render(rv1, "operators",
-		regv1render.WithProvidedAPIsClusterRoles(),
+	objs, err := regv1.Render(rv1, "operators",
+		regv1.WithProvidedAPIsClusterRoles(),
 	)
 	if err != nil {
 		panic(err)
@@ -108,7 +108,7 @@ func ExampleFromFS() {
 		},
 	}
 
-	source := regv1render.FromFS(bundleFS)
+	source := regv1.FromFS(bundleFS)
 	_, err := source.GetBundle()
 
 	// This will fail because the bundle is incomplete (no CSV),
@@ -124,7 +124,7 @@ func ExampleFromBundle() {
 	rv1 := exampleBundle()
 
 	// Wrap an already-parsed bundle as a BundleSource
-	source := regv1render.FromBundle(rv1)
+	source := regv1.FromBundle(rv1)
 	bundle, err := source.GetBundle()
 	if err != nil {
 		panic(err)
@@ -141,7 +141,7 @@ func ExampleRendererBuilder() {
 	rv1 := exampleBundle()
 
 	// Use NewRendererBuilder for full control
-	objs, err := regv1render.NewRendererBuilder().Build().Render(rv1, "operators")
+	objs, err := regv1.NewRendererBuilder().Build().Render(rv1, "operators")
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -54,10 +54,11 @@ func exampleBundle() regv1.RegistryV1 {
 	}
 }
 
-func ExampleRender() {
-	rv1 := exampleBundle()
+func ExampleRenderer() {
+	bundle := exampleBundle()
 
-	objs, err := regv1.Render(rv1, "operators")
+	renderer := regv1.NewRendererBuilder().Build()
+	objs, err := renderer.Render(bundle, "operators")
 	if err != nil {
 		panic(err)
 	}
@@ -67,10 +68,11 @@ func ExampleRender() {
 	// Rendered 2 objects
 }
 
-func ExampleRender_withTargetNamespaces() {
-	rv1 := exampleBundle()
+func ExampleRenderer_withTargetNamespaces() {
+	bundle := exampleBundle()
 
-	objs, err := regv1.Render(rv1, "operators",
+	renderer := regv1.NewRendererBuilder().Build()
+	objs, err := renderer.Render(bundle, "operators",
 		regv1.WithTargetNamespaces("watch-ns"),
 	)
 	if err != nil {
@@ -82,10 +84,11 @@ func ExampleRender_withTargetNamespaces() {
 	// Rendered 2 objects
 }
 
-func ExampleRender_withProvidedAPIsClusterRoles() {
-	rv1 := exampleBundle()
+func ExampleRenderer_withProvidedAPIsClusterRoles() {
+	bundle := exampleBundle()
 
-	objs, err := regv1.Render(rv1, "operators",
+	renderer := regv1.NewRendererBuilder().Build()
+	objs, err := renderer.Render(bundle, "operators",
 		regv1.WithProvidedAPIsClusterRoles(),
 	)
 	if err != nil {
@@ -97,9 +100,23 @@ func ExampleRender_withProvidedAPIsClusterRoles() {
 	// Rendered 6 objects (includes provided API ClusterRoles)
 }
 
+func ExampleRenderer_withCertManager() {
+	bundle := exampleBundle()
+
+	renderer := regv1.NewRendererBuilder().
+		WithCertificateProvider(regv1.CertManagerProvider{}).
+		Build()
+	objs, err := renderer.Render(bundle, "operators")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Rendered %d objects\n", len(objs))
+	// Output:
+	// Rendered 2 objects
+}
+
 func ExampleFromFS() {
-	// Create an in-memory filesystem representing a bundle
-	// In practice, this would be os.DirFS("path/to/bundle")
 	bundleFS := fstest.MapFS{
 		"metadata/annotations.yaml": &fstest.MapFile{
 			Data: []byte(`annotations:
@@ -111,8 +128,6 @@ func ExampleFromFS() {
 	source := regv1.FromFS(bundleFS)
 	_, err := source.GetBundle()
 
-	// This will fail because the bundle is incomplete (no CSV),
-	// but it demonstrates the FromFS API
 	if err != nil {
 		fmt.Println("FromFS loaded bundle source (bundle parsing requires a valid CSV)")
 	}
@@ -123,7 +138,6 @@ func ExampleFromFS() {
 func ExampleFromBundle() {
 	rv1 := exampleBundle()
 
-	// Wrap an already-parsed bundle as a BundleSource
 	source := regv1.FromBundle(rv1)
 	bundle, err := source.GetBundle()
 	if err != nil {
@@ -135,18 +149,4 @@ func ExampleFromBundle() {
 	// Output:
 	// Bundle: my-operator
 	// CSV: my-operator.v1.0.0
-}
-
-func ExampleRendererBuilder() {
-	rv1 := exampleBundle()
-
-	// Use NewRendererBuilder for full control
-	objs, err := regv1.NewRendererBuilder().Build().Render(rv1, "operators")
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("Rendered %d objects using DefaultRenderer\n", len(objs))
-	// Output:
-	// Rendered 2 objects using DefaultRenderer
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/perdasilva/regv1render
+module github.com/perdasilva/rv1
 
 go 1.25.7
 

--- a/internal/bundle/source/source.go
+++ b/internal/bundle/source/source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-registry/alpha/property"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
+	"github.com/perdasilva/rv1/internal/bundle"
 )
 
 const (

--- a/internal/bundle/source/source_test.go
+++ b/internal/bundle/source/source_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/bundle/source"
-	"github.com/perdasilva/regv1render/internal/util/testutil/bundlefs"
-	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/bundle/source"
+	"github.com/perdasilva/rv1/internal/util/testutil/bundlefs"
+	"github.com/perdasilva/rv1/internal/util/testutil/clusterserviceversion"
 )
 
 const (

--- a/internal/render/certproviders/certmanager.go
+++ b/internal/render/certproviders/certmanager.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/rv1/internal/render"
 )
 
 const (

--- a/internal/render/certproviders/certmanager_test.go
+++ b/internal/render/certproviders/certmanager_test.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
-	"github.com/perdasilva/regv1render/internal/render/certproviders"
+	"github.com/perdasilva/rv1/internal/render"
+	"github.com/perdasilva/rv1/internal/render/certproviders"
 )
 
 func Test_CertManagerProvider_InjectCABundle(t *testing.T) {

--- a/internal/render/certproviders/openshift_serviceca.go
+++ b/internal/render/certproviders/openshift_serviceca.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/rv1/internal/render"
 )
 
 const (

--- a/internal/render/certproviders/openshift_serviceca_test.go
+++ b/internal/render/certproviders/openshift_serviceca_test.go
@@ -10,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
-	"github.com/perdasilva/regv1render/internal/render/certproviders"
+	"github.com/perdasilva/rv1/internal/render"
+	"github.com/perdasilva/rv1/internal/render/certproviders"
 )
 
 func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {

--- a/internal/render/certproviders/secret.go
+++ b/internal/render/certproviders/secret.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/rv1/internal/render"
 )
 
 var _ render.CertificateProvider = (*SecretCertProvider)(nil)

--- a/internal/render/certproviders/secret_test.go
+++ b/internal/render/certproviders/secret_test.go
@@ -8,8 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/perdasilva/regv1render/internal/render"
-	"github.com/perdasilva/regv1render/internal/render/certproviders"
+	"github.com/perdasilva/rv1/internal/render"
+	"github.com/perdasilva/rv1/internal/render/certproviders"
 )
 
 func TestSecretCertProvider_InjectCABundle(t *testing.T) {

--- a/internal/render/generators.go
+++ b/internal/render/generators.go
@@ -22,8 +22,8 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	registrybundle "github.com/operator-framework/operator-registry/pkg/lib/bundle"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render/resourceutil"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/render/resourceutil"
 )
 
 const (

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render/validator"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/render/validator"
 )
 
 // DeploymentConfig is a type alias for v1alpha1.SubscriptionConfig

--- a/internal/render/renderer_test.go
+++ b/internal/render/renderer_test.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render"
-	. "github.com/perdasilva/regv1render/internal/util/testutil"
-	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/render"
+	. "github.com/perdasilva/rv1/internal/util/testutil"
+	"github.com/perdasilva/rv1/internal/util/testutil/clusterserviceversion"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/render/resourceutil/resourceutil_test.go
+++ b/internal/render/resourceutil/resourceutil_test.go
@@ -12,8 +12,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
-	"github.com/perdasilva/regv1render/internal/render/resourceutil"
+	"github.com/perdasilva/rv1/internal/render"
+	"github.com/perdasilva/rv1/internal/render/resourceutil"
 )
 
 func Test_OptionsApplyToExecutesIgnoresNil(t *testing.T) {

--- a/internal/render/util_test.go
+++ b/internal/render/util_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/rv1/internal/render"
 )
 
 type unmarshalable struct{}

--- a/internal/render/validator/validator.go
+++ b/internal/render/validator/validator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	regv1bundle "github.com/operator-framework/operator-registry/pkg/lib/bundle"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
+	"github.com/perdasilva/rv1/internal/bundle"
 )
 
 // BundleValidator validates a RegistryV1 bundle by running all checks.

--- a/internal/render/validator/validator_test.go
+++ b/internal/render/validator/validator_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render/validator"
-	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/render/validator"
+	"github.com/perdasilva/rv1/internal/util/testutil/clusterserviceversion"
 )
 
 var v = validator.BundleValidator{}

--- a/internal/util/testutil/bundlefs/bundlefs.go
+++ b/internal/util/testutil/bundlefs/bundlefs.go
@@ -12,8 +12,8 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-registry/alpha/property"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/bundle/source"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/bundle/source"
 )
 
 const (

--- a/internal/util/testutil/bundlefs/bundlefs_test.go
+++ b/internal/util/testutil/bundlefs/bundlefs_test.go
@@ -8,8 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/perdasilva/regv1render/internal/util/testutil/bundlefs"
-	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
+	"github.com/perdasilva/rv1/internal/util/testutil/bundlefs"
+	"github.com/perdasilva/rv1/internal/util/testutil/clusterserviceversion"
 )
 
 func Test_BundleFSBuilder(t *testing.T) {

--- a/internal/util/testutil/clusterserviceversion/builder_test.go
+++ b/internal/util/testutil/clusterserviceversion/builder_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render/internal/util/testutil/clusterserviceversion"
+	"github.com/perdasilva/rv1/internal/util/testutil/clusterserviceversion"
 )
 
 func Test_Builder(t *testing.T) {

--- a/internal/util/testutil/testing.go
+++ b/internal/util/testutil/testing.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/render"
 )
 
 type FakeCertProvider struct {

--- a/providedapis_test.go
+++ b/providedapis_test.go
@@ -54,7 +54,7 @@ func TestWithProvidedAPIsClusterRoles(t *testing.T) {
 	}
 
 	t.Run("without option produces no provided API roles", func(t *testing.T) {
-		objs, err := regv1.Render(rv1, "test-ns")
+		objs, err := regv1.NewRendererBuilder().Build().Render(rv1, "test-ns")
 		require.NoError(t, err)
 
 		for _, obj := range objs {
@@ -67,7 +67,7 @@ func TestWithProvidedAPIsClusterRoles(t *testing.T) {
 	})
 
 	t.Run("with option produces provided API roles", func(t *testing.T) {
-		objs, err := regv1.Render(rv1, "test-ns",
+		objs, err := regv1.NewRendererBuilder().Build().Render(rv1, "test-ns",
 			regv1.WithProvidedAPIsClusterRoles(),
 		)
 		require.NoError(t, err)

--- a/providedapis_test.go
+++ b/providedapis_test.go
@@ -1,4 +1,4 @@
-package regv1render_test
+package rv1_test
 
 import (
 	"testing"
@@ -11,11 +11,11 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	"github.com/perdasilva/regv1render"
+	regv1 "github.com/perdasilva/rv1"
 )
 
 func TestWithProvidedAPIsClusterRoles(t *testing.T) {
-	rv1 := regv1render.RegistryV1{
+	rv1 := regv1.RegistryV1{
 		PackageName: "test-operator",
 		CSV: v1alpha1.ClusterServiceVersion{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-operator.v1.0.0"},
@@ -54,7 +54,7 @@ func TestWithProvidedAPIsClusterRoles(t *testing.T) {
 	}
 
 	t.Run("without option produces no provided API roles", func(t *testing.T) {
-		objs, err := regv1render.Render(rv1, "test-ns")
+		objs, err := regv1.Render(rv1, "test-ns")
 		require.NoError(t, err)
 
 		for _, obj := range objs {
@@ -67,8 +67,8 @@ func TestWithProvidedAPIsClusterRoles(t *testing.T) {
 	})
 
 	t.Run("with option produces provided API roles", func(t *testing.T) {
-		objs, err := regv1render.Render(rv1, "test-ns",
-			regv1render.WithProvidedAPIsClusterRoles(),
+		objs, err := regv1.Render(rv1, "test-ns",
+			regv1.WithProvidedAPIsClusterRoles(),
 		)
 		require.NoError(t, err)
 

--- a/render.go
+++ b/render.go
@@ -1,8 +1,6 @@
 package rv1
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/perdasilva/rv1/internal/bundle"
 	"github.com/perdasilva/rv1/internal/render"
 	"github.com/perdasilva/rv1/internal/render/certproviders"
@@ -91,13 +89,4 @@ func WithProvidedAPIsClusterRoles() RenderOption {
 // WithTargetNamespaces sets the namespaces the operator should watch.
 func WithTargetNamespaces(namespaces ...string) RenderOption {
 	return render.WithTargetNamespaces(namespaces...)
-}
-
-// DefaultRenderer is a pre-configured Renderer with default settings.
-var DefaultRenderer = NewRendererBuilder().Build()
-
-// Render is a convenience function that renders a registry+v1 bundle
-// using the DefaultRenderer.
-func Render(rv1 RegistryV1, installNamespace string, opts ...RenderOption) ([]client.Object, error) {
-	return DefaultRenderer.Render(rv1, installNamespace, opts...)
 }

--- a/render.go
+++ b/render.go
@@ -1,12 +1,12 @@
-package regv1render
+package rv1
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/perdasilva/regv1render/internal/bundle"
-	"github.com/perdasilva/regv1render/internal/render"
-	"github.com/perdasilva/regv1render/internal/render/certproviders"
-	"github.com/perdasilva/regv1render/internal/render/validator"
+	"github.com/perdasilva/rv1/internal/bundle"
+	"github.com/perdasilva/rv1/internal/render"
+	"github.com/perdasilva/rv1/internal/render/certproviders"
+	"github.com/perdasilva/rv1/internal/render/validator"
 )
 
 // Renderer validates and renders registry+v1 bundles to plain
@@ -50,8 +50,8 @@ type RendererBuilder struct {
 // NewRendererBuilder creates a RendererBuilder with the standard
 // registry+v1 validator and generators.
 //
-//	r := regv1render.NewRendererBuilder().
-//	    WithCertificateProvider(regv1render.CertManagerProvider{}).
+//	r := rv1.NewRendererBuilder().
+//	    WithCertificateProvider(rv1.CertManagerProvider{}).
 //	    WithProvidedAPIsClusterRoles().
 //	    Build()
 func NewRendererBuilder() *RendererBuilder {

--- a/source.go
+++ b/source.go
@@ -1,9 +1,9 @@
-package regv1render
+package rv1
 
 import (
 	"io/fs"
 
-	"github.com/perdasilva/regv1render/internal/bundle/source"
+	"github.com/perdasilva/rv1/internal/bundle/source"
 )
 
 // BundleSource loads a registry+v1 bundle from some backing store.

--- a/specs/2026-04-22-issue-1-project-scaffolding/plan.md
+++ b/specs/2026-04-22-issue-1-project-scaffolding/plan.md
@@ -6,8 +6,8 @@ Set up the foundational project structure, build system, and CI pipeline so that
 
 Initialize the Go module and create minimal source files so the project compiles.
 
-- Initialize `go.mod` with module path `github.com/perdasilva/regv1render` and Go 1.25
-- Create `doc.go` at the repo root with a `package regv1render` declaration and a package-level doc comment
+- Initialize `go.mod` with module path `github.com/perdasilva/rv1` and Go 1.25
+- Create `doc.go` at the repo root with a `package rv1` declaration and a package-level doc comment
 - Create `cmd/rv1/main.go` with a minimal `main` package that prints a placeholder message
 - Run `go mod tidy` to ensure the module is valid
 

--- a/specs/2026-04-22-issue-2-port-render-logic/plan.md
+++ b/specs/2026-04-22-issue-2-port-render-logic/plan.md
@@ -50,7 +50,7 @@ Create the thin public API at the repo root that re-exports the key types and pr
 - Export cert provider types (`CertManagerProvider`, `OpenShiftServiceCAProvider`)
 - Keep internal implementation details (individual generators, validators, cert provider impls) under `internal/`
 - Write godoc comments for all public types, interfaces, and functions
-- Verify consumers can import `github.com/perdasilva/regv1render` and render a bundle
+- Verify consumers can import `github.com/perdasilva/rv1` and render a bundle
 
 ## Task Group 5: Clean up and refactor (medium)
 

--- a/specs/2026-04-22-issue-2-port-render-logic/requirements.md
+++ b/specs/2026-04-22-issue-2-port-render-logic/requirements.md
@@ -10,7 +10,7 @@
 - DeploymentConfig / SubscriptionConfig support is ported
 - All upstream unit tests pass against the ported code
 - All upstream regression tests pass — golden-file tests verify rendered output byte-for-byte against 107 expected YAML fixtures across 7 test cases
-- The public API is importable at `github.com/perdasilva/regv1render`
+- The public API is importable at `github.com/perdasilva/rv1`
 
 ## Non-Functional Requirements
 

--- a/specs/2026-04-22-issue-2-port-render-logic/validation.md
+++ b/specs/2026-04-22-issue-2-port-render-logic/validation.md
@@ -5,7 +5,7 @@
 1. `go build ./...` compiles the entire module including all ported code
 2. `go test ./...` passes — all upstream unit and regression tests ported and green
 3. `make verify` passes (fmt + vet + lint + test)
-4. The public API at `github.com/perdasilva/regv1render` exports: `BundleRenderer`, `BundleValidator`, `ResourceGenerator`, `Options`, `CertificateProvider`, and a default `Renderer`
+4. The public API at `github.com/perdasilva/rv1` exports: `BundleRenderer`, `BundleValidator`, `ResourceGenerator`, `Options`, `CertificateProvider`, and a default `Renderer`
 5. All public types and functions have godoc comments
 6. No `internal/` package imports the root package
 7. `make build` still produces a working rv1 binary
@@ -15,7 +15,7 @@
 - Run `go test ./...` — all ported upstream unit tests pass
 - Run regression tests — all 7 golden-file cases pass (argocd AllNamespaces/SingleNamespace/OwnNamespace, webhook all types, DeploymentConfig options, empty Affinity, empty Affinity subtype)
 - Run `make verify` — fmt, vet, lint, test all pass
-- Write a small integration snippet that imports `regv1render`, creates a default renderer, and calls Render on a minimal bundle — verify it compiles
+- Write a small integration snippet that imports `rv1`, creates a default renderer, and calls Render on a minimal bundle — verify it compiles
 - Verify no import cycles: `go vet ./...` should catch these
 
 ## Quality Gates
@@ -29,6 +29,6 @@
 ## Manual Verification
 
 1. Run `go test -v ./internal/...` and verify test names match upstream
-2. Run `go doc github.com/perdasilva/regv1render` and verify the public API is clean and documented
+2. Run `go doc github.com/perdasilva/rv1` and verify the public API is clean and documented
 3. Inspect `go.mod` — verify all expected dependencies are present
 4. Check `internal/` directory structure — verify it mirrors upstream package organization

--- a/specs/2026-04-22-issue-3-olmv0-compat/validation.md
+++ b/specs/2026-04-22-issue-3-olmv0-compat/validation.md
@@ -29,6 +29,6 @@
 
 ## Manual Verification
 
-1. Run `go doc github.com/perdasilva/regv1render WithProvidedAPIsClusterRoles` — verify godoc exists
+1. Run `go doc github.com/perdasilva/rv1 WithProvidedAPIsClusterRoles` — verify godoc exists
 2. Run `go test -v -run ProvidedAPI ./...` — verify new tests pass
 3. Run existing regression tests — verify no golden file changes

--- a/specs/2026-04-22-issue-4-rv1-cli/plan.md
+++ b/specs/2026-04-22-issue-4-rv1-cli/plan.md
@@ -8,10 +8,10 @@ Set up the cobra-based CLI with the `render` subcommand and stdin tar reading.
 
 - Add `github.com/spf13/cobra` dependency (already a transitive dep via controller-runtime)
 - Replace the placeholder `cmd/rv1/main.go` with a cobra root command and `render` subcommand
-- Implement stdin tar reading: read a tar stream, extract it to a temporary `fs.FS`, pass to `regv1render.FromFS()`
+- Implement stdin tar reading: read a tar stream, extract it to a temporary `fs.FS`, pass to `rv1.FromFS()`
 - Add `--install-namespace` flag (required)
 - Add `--watch-namespace` flag (optional, repeatable)
-- Render the bundle using `regv1render.Render()` and output multi-document YAML (`---` separated) to stdout
+- Render the bundle using `rv1.Render()` and output multi-document YAML (`---` separated) to stdout
 - Verify basic flow works: `crane export <image> - | rv1 render --install-namespace test-ns`
 
 ## Task Group 2: Config file support (medium)

--- a/specs/2026-04-22-issue-4-rv1-cli/requirements.md
+++ b/specs/2026-04-22-issue-4-rv1-cli/requirements.md
@@ -30,4 +30,4 @@
 
 - `github.com/spf13/cobra` (CLI framework, already a transitive dep)
 - `sigs.k8s.io/yaml` (config file parsing, already a dep)
-- `regv1render` public API (FromFS, Render, With* options)
+- `rv1` public API (FromFS, Render, With* options)

--- a/specs/2026-04-22-issue-5-documentation/plan.md
+++ b/specs/2026-04-22-issue-5-documentation/plan.md
@@ -1,6 +1,6 @@
 # Documentation & Examples
 
-Provide comprehensive documentation and usage examples for the regv1render library and rv1 CLI. Add testable examples that appear in godoc, a CONTRIBUTING.md for contributors, and enhance the README with upstream relationship context.
+Provide comprehensive documentation and usage examples for the rv1 library and rv1 CLI. Add testable examples that appear in godoc, a CONTRIBUTING.md for contributors, and enhance the README with upstream relationship context.
 
 ## Task Group 1: Testable examples for godoc (medium)
 
@@ -22,7 +22,7 @@ Review and improve godoc comments across the public API.
 - Check all exported types, functions, and variables in `render.go`, `source.go`, `certproviders.go`, `doc.go`
 - Ensure doc comments are complete, accurate, and follow Go conventions (start with the name of the thing being documented)
 - Add package-level documentation to `doc.go` describing the library's purpose, relationship to upstream, and basic usage
-- Run `go doc github.com/perdasilva/regv1render` and verify the output is clean
+- Run `go doc github.com/perdasilva/rv1` and verify the output is clean
 
 ## Task Group 3: README enhancements (small)
 
@@ -49,6 +49,6 @@ Create a contributor guide covering the development workflow.
 Verify all documentation is consistent and accurate.
 
 - Run `make verify` — all tests (including examples) pass
-- Run `go doc github.com/perdasilva/regv1render` — verify clean output with examples
+- Run `go doc github.com/perdasilva/rv1` — verify clean output with examples
 - Read through README and CONTRIBUTING end-to-end for coherence
 - Update CLAUDE.md if needed

--- a/specs/2026-04-22-issue-5-documentation/validation.md
+++ b/specs/2026-04-22-issue-5-documentation/validation.md
@@ -3,7 +3,7 @@
 ## Acceptance Criteria
 
 1. `go test -run Example ./` passes — all testable examples compile and run
-2. `go doc github.com/perdasilva/regv1render` shows examples in output
+2. `go doc github.com/perdasilva/rv1` shows examples in output
 3. All public types and functions have godoc comments
 4. CONTRIBUTING.md exists with prerequisites, build, test, conventions, and PR process
 5. README has upstream relationship section
@@ -14,8 +14,8 @@
 ## Test Scenarios
 
 - Run `go test -run Example -v ./` — verify all examples pass and produce expected output
-- Run `go doc github.com/perdasilva/regv1render Render` — verify example appears
-- Run `go doc github.com/perdasilva/regv1render FromFS` — verify example appears
+- Run `go doc github.com/perdasilva/rv1 Render` — verify example appears
+- Run `go doc github.com/perdasilva/rv1 FromFS` — verify example appears
 - Read CONTRIBUTING.md — verify it covers clone, build, test, branch, commit, PR
 - Read README — verify upstream relationship section is present and accurate
 - Read README — verify OLMv0 section explains WithProvidedAPIsClusterRoles
@@ -29,6 +29,6 @@
 
 ## Manual Verification
 
-1. Run `go doc github.com/perdasilva/regv1render` — review the full package documentation
+1. Run `go doc github.com/perdasilva/rv1` — review the full package documentation
 2. Read README.md end-to-end — verify it tells a coherent story
 3. Read CONTRIBUTING.md — verify a new contributor could follow the instructions

--- a/specs/2026-04-23-issue-15-cli-cert-provider/plan.md
+++ b/specs/2026-04-23-issue-15-cli-cert-provider/plan.md
@@ -9,8 +9,8 @@ Add the discriminated union struct and wire it into the config parser.
 - Add `CertificateProviderConfig` struct with `Type` field to `cmd/rv1/render.go`
 - Add `CertificateProvider *CertificateProviderConfig` field to `renderConfig`
 - Map `type` values in `buildRenderOptions()`:
-  - `cert-manager` → `regv1render.WithCertificateProvider(regv1render.CertManagerProvider{})`
-  - `openshift-service-ca` → `regv1render.WithCertificateProvider(regv1render.OpenShiftServiceCAProvider{})`
+  - `cert-manager` → `rv1.WithCertificateProvider(rv1.CertManagerProvider{})`
+  - `openshift-service-ca` → `rv1.WithCertificateProvider(rv1.OpenShiftServiceCAProvider{})`
   - `none` or nil → no provider (default, current behavior)
 - Validate `type` — reject unknown values with a clear error message
 

--- a/specs/2026-04-23-issue-15-cli-cert-provider/requirements.md
+++ b/specs/2026-04-23-issue-15-cli-cert-provider/requirements.md
@@ -24,4 +24,4 @@
 
 ## Dependencies
 
-- `regv1render` public API: `WithCertificateProvider()`, `CertManagerProvider`, `OpenShiftServiceCAProvider`
+- `rv1` public API: `WithCertificateProvider()`, `CertManagerProvider`, `OpenShiftServiceCAProvider`

--- a/specs/2026-04-23-issue-17-concrete-validator/validation.md
+++ b/specs/2026-04-23-issue-17-concrete-validator/validation.md
@@ -31,6 +31,6 @@
 
 ## Manual Verification
 
-1. `go doc github.com/perdasilva/regv1render ValidationError` — verify type is documented
-2. `go doc github.com/perdasilva/regv1render` — verify `BundleValidator` is gone
+1. `go doc github.com/perdasilva/rv1 ValidationError` — verify type is documented
+2. `go doc github.com/perdasilva/rv1` — verify `BundleValidator` is gone
 3. Run `go test -v ./internal/render/registryv1/validator/` — verify tests pass and use `Validate()`

--- a/specs/2026-04-23-issue-18-concrete-renderer/validation.md
+++ b/specs/2026-04-23-issue-18-concrete-renderer/validation.md
@@ -10,7 +10,7 @@
 6. CLI uses `NewRenderer` + `Render` pattern
 7. `make verify` passes
 8. All regression tests pass without golden file changes
-9. `go doc github.com/perdasilva/regv1render` shows simplified API
+9. `go doc github.com/perdasilva/rv1` shows simplified API
 
 ## Test Scenarios
 
@@ -31,6 +31,6 @@
 
 ## Manual Verification
 
-1. `go doc github.com/perdasilva/regv1render` — verify simplified API
+1. `go doc github.com/perdasilva/rv1` — verify simplified API
 2. `make build && bin/rv1 render --help` — CLI still works
 3. Run regression tests — golden files unchanged

--- a/specs/2026-04-23-issue-24-merge-generators/validation.md
+++ b/specs/2026-04-23-issue-24-merge-generators/validation.md
@@ -33,6 +33,6 @@
 
 ## Manual Verification
 
-1. `go doc github.com/perdasilva/regv1render` — no `ResourceGenerator` types
+1. `go doc github.com/perdasilva/rv1` — no `ResourceGenerator` types
 2. Run `make build && bin/rv1 --version` — CLI works
 3. Run regression tests — golden files unchanged

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -3,12 +3,12 @@
 ## Language & Runtime
 
 - **Language:** Go 1.25
-- **Module path:** `github.com/perdasilva/regv1render`
+- **Module path:** `github.com/perdasilva/rv1`
 
 ## Project Structure
 
 ```
-regv1render/
+rv1/
 ├── render.go            # public API entry points
 ├── types.go             # public types and interfaces
 ├── render_test.go       # tests

--- a/test/regression/generate-manifests.go
+++ b/test/regression/generate-manifests.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/perdasilva/regv1render/internal/bundle/source"
-	"github.com/perdasilva/regv1render/internal/render"
-	"github.com/perdasilva/regv1render/internal/render/certproviders"
+	"github.com/perdasilva/rv1/internal/bundle/source"
+	"github.com/perdasilva/rv1/internal/render"
+	"github.com/perdasilva/rv1/internal/render/certproviders"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Rename Go module path from `github.com/perdasilva/regv1render` to `github.com/perdasilva/rv1` to match renamed repository
- Rename root package from `regv1render` to `rv1`
- Remove `DefaultRenderer` and convenience `Render()` function — users now use `rv1.NewRendererBuilder().Build()` explicitly
- Update README usage examples to show builder pattern with cert provider and deployment config
- Update all import paths, Makefile, golangci-lint config, docs, and specs

## Test Plan
- [x] `make verify` passes
- [x] `make build && bin/rv1 --version` works
- [x] No remaining `regv1render` references in tracked code
- [x] All example tests use builder pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)